### PR TITLE
Rate Limiting

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@
 DATABASE_URL              = "postgres://localhost/horizon_development?sslmode=disable"
 STELLAR_CORE_DATABASE_URL = "postgres://localhost/hayashi_development?sslmode=disable"
 STELLAR_CORE_URL          = "http://localhost:39132"
+REDIS_URL                 = "redis://127.0.0.1:6379"
 DISABLE_RATE_LIMIT        = true
 FRIENDBOT_SECRET          = "sfyjodTxbwLtRToZvi6yQ1KnpZriwTJ7n6nrASFR6goRviCU3Ff"
 SECRET_KEY_BASE           = "c1444052ef5183c4e6f8e4c6f18a5034902f3e9833a022cecb99005ad86a6927fa40db442e80c22b7a62186753fd7e507baf62408904465b3637101f933ad8ed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ env:
 notifications:
   slack:
     secure: aZZCo+1qY0AIT4TJ0Q218XZbPzxNMPLznXI8CgWVAuI+6ipRWIWykaeB0H6EInejXuT8Cjx3OKxk6RCNPLiBr10TgDnEOPR2ycPXGHSjwE+omte8/Uq3VxfEU45Uh3AlwleMIn9/HVGgGxRGEY4GqUeA9+QPPZt2sswiVazbkx4=
+services:
+  - redis-server

--- a/account_actions_test.go
+++ b/account_actions_test.go
@@ -12,6 +12,7 @@ func TestAccountActions(t *testing.T) {
 	Convey("Account Actions:", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
+		defer app.Cancel()
 		rh := NewRequestHelper(app)
 
 		Convey("GET /accounts/gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC", func() {

--- a/app.go
+++ b/app.go
@@ -32,11 +32,7 @@ func NewApp(config Config) (*App, error) {
 		cancel:  cancel,
 	}
 
-	web, err := NewWeb(&result)
-
-	if err != nil {
-		return nil, err
-	}
+	NewWeb(&result)
 
 	historyDb, err := db.Open(config.DatabaseUrl)
 
@@ -52,7 +48,6 @@ func NewApp(config Config) (*App, error) {
 
 	result.metrics.Register("db.active_query_count", db.QueryGauge())
 
-	result.web = web
 	result.historyDb = historyDb
 	result.coreDb = coreDb
 	return &result, nil

--- a/app.go
+++ b/app.go
@@ -34,7 +34,6 @@ func NewApp(config Config) (*App, error) {
 		cancel:  cancel,
 	}
 
-	NewWeb(&result)
 	err := NewRedis(&result)
 
 	if err != nil {
@@ -57,6 +56,9 @@ func NewApp(config Config) (*App, error) {
 
 	result.historyDb = historyDb
 	result.coreDb = coreDb
+
+	NewWeb(&result)
+
 	return &result, nil
 }
 
@@ -94,6 +96,8 @@ func (a *App) Serve() {
 }
 
 func (a *App) Cancel() {
+	a.historyDb.Close()
+	a.coreDb.Close()
 	a.cancel()
 }
 

--- a/app.go
+++ b/app.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"fmt"
+	"github.com/garyburd/redigo/redis"
 	"github.com/jinzhu/gorm"
 	"github.com/rcrowley/go-metrics"
 	"github.com/stellar/go-horizon/db"
@@ -20,6 +21,7 @@ type App struct {
 	coreDb    gorm.DB
 	ctx       context.Context
 	cancel    func()
+	redis     *redis.Pool
 }
 
 func NewApp(config Config) (*App, error) {
@@ -33,6 +35,11 @@ func NewApp(config Config) (*App, error) {
 	}
 
 	NewWeb(&result)
+	err := NewRedis(&result)
+
+	if err != nil {
+		return nil, err
+	}
 
 	historyDb, err := db.Open(config.DatabaseUrl)
 

--- a/cmd/horizon/main.go
+++ b/cmd/horizon/main.go
@@ -29,6 +29,7 @@ func init() {
 	viper.BindEnv("stellar-core-url", "STELLAR_CORE_URL")
 	viper.BindEnv("friendbot-secret", "FRIENDBOT_SECRET")
 	viper.BindEnv("per-hour-rate-limit", "PER_HOUR_RATE_LIMIT")
+	viper.BindEnv("redis-url", "REDIS_URL")
 
 	rootCmd = &cobra.Command{
 		Use:   "horizon",
@@ -73,6 +74,12 @@ func init() {
 		"max count of requests allowed in a one hour period, by remote ip address",
 	)
 
+	rootCmd.Flags().String(
+		"redis-url",
+		"",
+		"redis to connect with, for rate limiting",
+	)
+
 	viper.BindPFlags(rootCmd.Flags())
 }
 
@@ -94,6 +101,7 @@ func run(cmd *cobra.Command, args []string) {
 		Autopump:               viper.GetBool("autopump"),
 		Port:                   viper.GetInt("port"),
 		RateLimit:              throttled.PerHour(viper.GetInt("per-hour-rate-limit")),
+		RedisUrl:               viper.GetString("redis-url"),
 	}
 
 	var err error

--- a/cmd/horizon/main.go
+++ b/cmd/horizon/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/PuerkitoBio/throttled"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stellar/go-horizon"
@@ -27,6 +28,7 @@ func init() {
 	viper.BindEnv("stellar-core-db-url", "STELLAR_CORE_DATABASE_URL")
 	viper.BindEnv("stellar-core-url", "STELLAR_CORE_URL")
 	viper.BindEnv("friendbot-secret", "FRIENDBOT_SECRET")
+	viper.BindEnv("per-hour-rate-limit", "PER_HOUR_RATE_LIMIT")
 
 	rootCmd = &cobra.Command{
 		Use:   "horizon",
@@ -65,6 +67,12 @@ func init() {
 		"pump streams every second, instead of once per ledger close",
 	)
 
+	rootCmd.Flags().Int(
+		"per-hour-rate-limit",
+		3600,
+		"max count of requests allowed in a one hour period, by remote ip address",
+	)
+
 	viper.BindPFlags(rootCmd.Flags())
 }
 
@@ -85,6 +93,7 @@ func run(cmd *cobra.Command, args []string) {
 		StellarCoreDatabaseUrl: viper.GetString("stellar-core-db-url"),
 		Autopump:               viper.GetBool("autopump"),
 		Port:                   viper.GetInt("port"),
+		RateLimit:              throttled.PerHour(viper.GetInt("per-hour-rate-limit")),
 	}
 
 	var err error

--- a/config.go
+++ b/config.go
@@ -1,8 +1,13 @@
 package horizon
 
+import (
+	"github.com/PuerkitoBio/throttled"
+)
+
 type Config struct {
 	DatabaseUrl            string
 	StellarCoreDatabaseUrl string
 	Port                   int
 	Autopump               bool
+	RateLimit              throttled.Quota
 }

--- a/config.go
+++ b/config.go
@@ -10,4 +10,5 @@ type Config struct {
 	Port                   int
 	Autopump               bool
 	RateLimit              throttled.Quota
+	RedisUrl               string
 }

--- a/docs/content/guide/rate_limiting.md
+++ b/docs/content/guide/rate_limiting.md
@@ -1,0 +1,22 @@
++++
+draft = false
+title = "Rate Limiting"
++++
+
+In order to provide service stability, horizon limits the number of requests a
+client can perform within a one hour window.  By default this is set to 3600
+requests per hour.
+
+## Response headers for rate limiting
+
+Every response from horizon sets advisory headers to inform clients of their
+standing with rate limiting system:
+
+|          Header         |                               Description                                |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `X-RateLimit-Limit`     | The maximum number of requests that the current client make in one hour. |
+| `X-RateLimit-Remaining` | The number of remaining requests for the current window.                 |
+| `X-RateLimit-Reset`     | Seconds until a new window starts                                        |
+
+In addition, a `Retry-After` header will be set when the current client is being
+throttled.

--- a/docs/content/problem/rate_limit_exceeded.md
+++ b/docs/content/problem/rate_limit_exceeded.md
@@ -1,0 +1,34 @@
++++
+draft     = false
+linktitle = "Rate Limit Exceeded"
+title     = "Problem: Rate Limit Exceeded"
++++
+
+A `rate_limit_exceeded` problem is returned from horizon when it receives too
+many requests within a one hour window from a single user.  By default, horizon
+allows 3600 requests per hour, an average of one per second.
+
+See the [rate limiting guide][rlg] for more info.
+
+## Example
+
+```json
+{
+  "type":     "https://www.stellar.org/docs/horizon/problems/rate_limit_exceeded",
+  "title":    "Rate Limit Exceeded",
+  "status":   429,
+  "details":  "...",
+  "instance": "d3465740-ec3a-4a0b-9d4a-c9ea734ce58a"
+}
+```
+
+## Tips for resolution
+
+Fundamentally, you need to reduce the number of requests you make to horizon per
+hour.  Here are some strategies to help you do this:
+
+- For collection endpoints, specify larger page sizes.
+- Use streaming responses to watch for new data rather than polling.
+- Locally cache immutable data, such as a transaction's details.
+
+[rlg]: {{< relref "guide/rate_limiting.md" >}}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"github.com/PuerkitoBio/throttled"
 	"github.com/stellar/go-horizon/test"
 	"log"
 )
@@ -9,6 +10,7 @@ func NewTestApp() *App {
 	app, err := NewApp(Config{
 		DatabaseUrl:            test.DatabaseUrl(),
 		StellarCoreDatabaseUrl: test.StellarCoreDatabaseUrl(),
+		RateLimit:              throttled.PerMin(10),
 	})
 
 	if err != nil {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -22,7 +22,7 @@ func NewTestConfig() Config {
 	return Config{
 		DatabaseUrl:            test.DatabaseUrl(),
 		StellarCoreDatabaseUrl: test.StellarCoreDatabaseUrl(),
-		RateLimit:              throttled.PerMin(10),
+		RateLimit:              throttled.PerHour(10),
 	}
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -7,11 +7,7 @@ import (
 )
 
 func NewTestApp() *App {
-	app, err := NewApp(Config{
-		DatabaseUrl:            test.DatabaseUrl(),
-		StellarCoreDatabaseUrl: test.StellarCoreDatabaseUrl(),
-		RateLimit:              throttled.PerMin(10),
-	})
+	app, err := NewApp(NewTestConfig())
 
 	if err != nil {
 		log.Panic(err)
@@ -20,6 +16,14 @@ func NewTestApp() *App {
 	app.historyDb.LogMode(true)
 
 	return app
+}
+
+func NewTestConfig() Config {
+	return Config{
+		DatabaseUrl:            test.DatabaseUrl(),
+		StellarCoreDatabaseUrl: test.StellarCoreDatabaseUrl(),
+		RateLimit:              throttled.PerMin(10),
+	}
 }
 
 func NewRequestHelper(app *App) test.RequestHelper {

--- a/ledger_actions_test.go
+++ b/ledger_actions_test.go
@@ -12,6 +12,7 @@ func TestLedgerActions(t *testing.T) {
 	Convey("Ledger Actions:", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
+		defer app.Cancel()
 		rh := NewRequestHelper(app)
 
 		Convey("GET /ledgers/1", func() {

--- a/rate_limit_exceeded_action.go
+++ b/rate_limit_exceeded_action.go
@@ -1,0 +1,11 @@
+package horizon
+
+import (
+	"github.com/stellar/go-horizon/render/problem"
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+func rateLimitExceededAction(w http.ResponseWriter, r *http.Request) {
+	problem.Render(context.TODO(), w, problem.RateLimitExceeded)
+}

--- a/rate_limit_middleware.go
+++ b/rate_limit_middleware.go
@@ -1,0 +1,10 @@
+package horizon
+
+import (
+	"github.com/zenazn/goji/web"
+	"net/http"
+)
+
+func (web *Web) RateLimitMiddleware(c *web.C, next http.Handler) http.Handler {
+	return web.rateLimiter.Throttle(next)
+}

--- a/rate_limit_middleware.go
+++ b/rate_limit_middleware.go
@@ -1,10 +1,32 @@
 package horizon
 
 import (
+	"github.com/PuerkitoBio/throttled"
+	"github.com/PuerkitoBio/throttled/store"
 	"github.com/zenazn/goji/web"
 	"net/http"
 )
 
 func (web *Web) RateLimitMiddleware(c *web.C, next http.Handler) http.Handler {
 	return web.rateLimiter.Throttle(next)
+}
+
+func installRateLimiter(web *Web, app *App) {
+	rateLimitStore := store.NewMemStore(1000)
+
+	if app.redis != nil {
+		rateLimitStore = store.NewRedisStore(app.redis, "throttle:", 0)
+	}
+
+	rateLimiter := throttled.RateLimit(
+		app.config.RateLimit,
+		&throttled.VaryBy{Custom: remoteAddrIp},
+		rateLimitStore,
+	)
+
+	web.rateLimiter = rateLimiter
+}
+
+func remoteAddrIp(r *http.Request) string {
+	return r.RemoteAddr
 }

--- a/rate_limit_middleware.go
+++ b/rate_limit_middleware.go
@@ -24,7 +24,7 @@ func installRateLimiter(web *Web, app *App) {
 		&throttled.VaryBy{Custom: remoteAddrIp},
 		rateLimitStore,
 	)
-
+	rateLimiter.DeniedHandler = http.HandlerFunc(rateLimitExceededAction)
 	web.rateLimiter = rateLimiter
 }
 

--- a/rate_limit_middleware.go
+++ b/rate_limit_middleware.go
@@ -5,6 +5,7 @@ import (
 	"github.com/PuerkitoBio/throttled/store"
 	"github.com/zenazn/goji/web"
 	"net/http"
+	"strings"
 )
 
 func (web *Web) RateLimitMiddleware(c *web.C, next http.Handler) http.Handler {
@@ -28,5 +29,6 @@ func installRateLimiter(web *Web, app *App) {
 }
 
 func remoteAddrIp(r *http.Request) string {
-	return r.RemoteAddr
+	ip := strings.SplitN(r.RemoteAddr, ":", 2)[0]
+	return ip
 }

--- a/rate_limit_middleware_test.go
+++ b/rate_limit_middleware_test.go
@@ -30,6 +30,10 @@ func TestRateLimitMiddleware(t *testing.T) {
 
 			w = rh.Get("/", test.RequestHelperRemoteAddr("127.0.0.2"))
 			So(w.Code, ShouldEqual, 200)
+
+			// Ignores ports
+			w = rh.Get("/", test.RequestHelperRemoteAddr("127.0.0.1:4312"))
+			So(w.Code, ShouldEqual, 429)
 		})
 
 		Convey("Restrict based upon X-Forwarded-For correctly", func() {

--- a/rate_limit_middleware_test.go
+++ b/rate_limit_middleware_test.go
@@ -48,4 +48,22 @@ func TestRateLimitMiddleware(t *testing.T) {
 
 		})
 	})
+
+	Convey("Rate Limiting works with redis", t, func() {
+		c := NewTestConfig()
+		c.RedisUrl = "redis://127.0.0.1:6379/"
+		app, _ := NewApp(c)
+		rh := NewRequestHelper(app)
+
+		for i := 0; i < 10; i++ {
+			w := rh.Get("/", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+		}
+
+		w := rh.Get("/", test.RequestHelperNoop)
+		So(w.Code, ShouldEqual, 429)
+
+		w = rh.Get("/", test.RequestHelperRemoteAddr("127.0.0.2"))
+		So(w.Code, ShouldEqual, 200)
+	})
 }

--- a/rate_limit_middleware_test.go
+++ b/rate_limit_middleware_test.go
@@ -1,0 +1,51 @@
+package horizon
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/go-horizon/test"
+	"testing"
+)
+
+func TestRateLimitMiddleware(t *testing.T) {
+
+	Convey("Rate Limiting", t, func() {
+		app := NewTestApp()
+		rh := NewRequestHelper(app)
+
+		Convey("Restricts based on RemoteAddr IP after too many requests", func() {
+			for i := 0; i < 10; i++ {
+				w := rh.Get("/", test.RequestHelperNoop)
+				So(w.Code, ShouldEqual, 200)
+			}
+
+			w := rh.Get("/", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 429)
+
+			w = rh.Get("/", test.RequestHelperRemoteAddr("127.0.0.2"))
+			So(w.Code, ShouldEqual, 200)
+		})
+
+		Convey("Restrict based upon X-Forwarded-For correctly", func() {
+			for i := 0; i < 10; i++ {
+				w := rh.Get("/", test.RequestHelperXFF("4.4.4.4"))
+				So(w.Code, ShouldEqual, 200)
+			}
+
+			w := rh.Get("/", test.RequestHelperXFF("4.4.4.4"))
+			So(w.Code, ShouldEqual, 429)
+
+			// allow other ips
+			w = rh.Get("/", test.RequestHelperRemoteAddr("4.4.4.3"))
+			So(w.Code, ShouldEqual, 200)
+
+			// Ignores leading private ips
+			w = rh.Get("/", test.RequestHelperXFF("10.0.0.1, 4.4.4.4"))
+			So(w.Code, ShouldEqual, 429)
+
+			// Ignores trailing ips
+			w = rh.Get("/", test.RequestHelperXFF("4.4.4.4, 4.4.4.5, 127.0.0.1"))
+			So(w.Code, ShouldEqual, 429)
+
+		})
+	})
+}

--- a/rate_limit_middleware_test.go
+++ b/rate_limit_middleware_test.go
@@ -3,6 +3,7 @@ package horizon
 import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stellar/go-horizon/test"
+	"strconv"
 	"testing"
 )
 
@@ -17,6 +18,20 @@ func TestRateLimitMiddleware(t *testing.T) {
 			w := rh.Get("/", test.RequestHelperNoop)
 			So(w.Code, ShouldEqual, 200)
 			So(w.Header().Get("X-RateLimit-Limit"), ShouldEqual, "10")
+		})
+
+		Convey("sets X-RateLimit-Remaining headers correctly", func() {
+			for i := 0; i < 10; i++ {
+				w := rh.Get("/", test.RequestHelperNoop)
+				expected := 10 - (i + 1)
+				So(w.Header().Get("X-RateLimit-Remaining"), ShouldEqual, strconv.Itoa(expected))
+			}
+
+			// confirm remaining stays at 0
+			for i := 0; i < 10; i++ {
+				w := rh.Get("/", test.RequestHelperNoop)
+				So(w.Header().Get("X-RateLimit-Remaining"), ShouldEqual, "0")
+			}
 		})
 
 		Convey("Restricts based on RemoteAddr IP after too many requests", func() {

--- a/rate_limit_middleware_test.go
+++ b/rate_limit_middleware_test.go
@@ -34,6 +34,11 @@ func TestRateLimitMiddleware(t *testing.T) {
 			}
 		})
 
+		Convey("sets X-RateLimit-Reset header correctly", func() {
+			w := rh.Get("/", test.RequestHelperNoop)
+			So(w.Header().Get("X-RateLimit-Reset"), ShouldEqual, "3599")
+		})
+
 		Convey("Restricts based on RemoteAddr IP after too many requests", func() {
 			for i := 0; i < 10; i++ {
 				w := rh.Get("/", test.RequestHelperNoop)

--- a/redis.go
+++ b/redis.go
@@ -1,0 +1,60 @@
+package horizon
+
+import (
+	"github.com/garyburd/redigo/redis"
+	"net/url"
+	"time"
+)
+
+func NewRedis(app *App) error {
+	if app.config.RedisUrl == "" {
+		return nil
+	}
+
+	redisUrl, err := url.Parse(app.config.RedisUrl)
+
+	if err != nil {
+		return err
+	}
+
+	app.redis = &redis.Pool{
+		MaxIdle:      3,
+		IdleTimeout:  240 * time.Second,
+		Dial:         dialRedis(redisUrl),
+		TestOnBorrow: pingRedis,
+	}
+
+	// test the connection
+	c := app.redis.Get()
+	defer c.Close()
+
+	_, err = c.Do("PING")
+	return err
+}
+
+func dialRedis(redisUrl *url.URL) func() (redis.Conn, error) {
+	return func() (redis.Conn, error) {
+		c, err := redis.Dial("tcp", redisUrl.Host)
+		if err != nil {
+			return nil, err
+		}
+
+		if redisUrl.User == nil {
+			return c, err
+		}
+
+		if pass, ok := redisUrl.User.Password(); ok {
+			if _, err := c.Do("AUTH", pass); err != nil {
+				c.Close()
+				return nil, err
+			}
+		}
+
+		return c, err
+	}
+}
+
+func pingRedis(c redis.Conn, t time.Time) error {
+	_, err := c.Do("PING")
+	return err
+}

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,0 +1,37 @@
+package horizon
+
+import (
+	"github.com/garyburd/redigo/redis"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestRedis(t *testing.T) {
+
+	Convey("app.redis gets set when RedisUrl is set", t, func() {
+		c := NewTestConfig()
+		c.RedisUrl = "redis://127.0.0.1:6379/"
+		app, _ := NewApp(c)
+		So(app.redis, ShouldNotBeNil)
+	})
+
+	Convey("app.redis is nil when no RedisUrl is set", t, func() {
+		c := NewTestConfig()
+		c.RedisUrl = ""
+		app, _ := NewApp(c)
+		So(app.redis, ShouldBeNil)
+	})
+
+	Convey("app.redis can successfully connect to redis", t, func() {
+		conf := NewTestConfig()
+		conf.RedisUrl = "redis://127.0.0.1:6379/"
+		app, _ := NewApp(conf)
+
+		c := app.redis.Get()
+		defer c.Close()
+
+		c.Do("SET", "hello", "World")
+		world, _ := redis.String(c.Do("GET", "hello"))
+		So(world, ShouldEqual, "World")
+	})
+}

--- a/redis_test.go
+++ b/redis_test.go
@@ -12,6 +12,7 @@ func TestRedis(t *testing.T) {
 		c := NewTestConfig()
 		c.RedisUrl = "redis://127.0.0.1:6379/"
 		app, _ := NewApp(c)
+		defer app.Cancel()
 		So(app.redis, ShouldNotBeNil)
 	})
 
@@ -19,6 +20,7 @@ func TestRedis(t *testing.T) {
 		c := NewTestConfig()
 		c.RedisUrl = ""
 		app, _ := NewApp(c)
+		defer app.Cancel()
 		So(app.redis, ShouldBeNil)
 	})
 
@@ -26,6 +28,7 @@ func TestRedis(t *testing.T) {
 		conf := NewTestConfig()
 		conf.RedisUrl = "redis://127.0.0.1:6379/"
 		app, _ := NewApp(conf)
+		defer app.Cancel()
 
 		c := app.redis.Get()
 		defer c.Close()

--- a/render/problem/main.go
+++ b/render/problem/main.go
@@ -77,7 +77,7 @@ func init() {
 	RateLimitExceeded = P{
 		Type:   "rate_limit_exceeded",
 		Title:  "Rate limit exceeded",
-		Status: http.StatusForbidden,
+		Status: 429,
 		Detail: "The rate limit for the requesting IP address is over its alloted " +
 			"limit.  The allowed limit and requests left per time period are " +
 			"communicated to clients via the http response headers 'X-RateLimit-*' " +

--- a/render/problem/main_test.go
+++ b/render/problem/main_test.go
@@ -30,7 +30,7 @@ func TestMain(t *testing.T) {
 
 		Convey("RateLimitExceeded", func() {
 			w := render(RateLimitExceeded)
-			So(w.Code, ShouldEqual, 403)
+			So(w.Code, ShouldEqual, 429)
 			t.Log(w.Body.String())
 		})
 	})

--- a/root_action_test.go
+++ b/root_action_test.go
@@ -11,6 +11,7 @@ func TestRootAction(t *testing.T) {
 	Convey("GET /", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
+		defer app.Cancel()
 		rh := NewRequestHelper(app)
 
 		w := rh.Get("/", test.RequestHelperNoop)

--- a/test/http.go
+++ b/test/http.go
@@ -18,6 +18,18 @@ func RequestHelperNoop(r *http.Request) {
 
 }
 
+func RequestHelperRemoteAddr(ip string) func(r *http.Request) {
+	return func(r *http.Request) {
+		r.RemoteAddr = ip
+	}
+}
+
+func RequestHelperXFF(xff string) func(r *http.Request) {
+	return func(r *http.Request) {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+}
+
 func NewRequestHelper(router *web.Mux) RequestHelper {
 	return &requestHelper{router}
 }
@@ -28,6 +40,7 @@ func (r *requestHelper) Get(
 ) *httptest.ResponseRecorder {
 
 	req, _ := http.NewRequest("GET", path, nil)
+	req.RemoteAddr = "127.0.0.1"
 	requestModFn(req)
 
 	w := httptest.NewRecorder()

--- a/web.go
+++ b/web.go
@@ -23,10 +23,16 @@ func NewWeb(app *App) {
 
 	api := web.New()
 
+	rateLimitStore := store.NewMemStore(1000)
+
+	if app.redis != nil {
+		rateLimitStore = store.NewRedisStore(app.redis, "throttle:", 0)
+	}
+
 	rateLimiter := throttled.RateLimit(
 		app.config.RateLimit,
 		&throttled.VaryBy{RemoteAddr: true},
-		store.NewMemStore(1000),
+		rateLimitStore,
 	)
 
 	result := Web{


### PR DESCRIPTION
This PR adds support for a configurable rate limiting system. It:
- adds `--redis-url` flag, which when sets initializes a redis connection pool on `App`
- adds `--per-hour-rate-limit` flag, defaulting to 3600
- by default will store data in a memory store, but will use redis if available
- adds middleware that overwrites `r.RemoteAddr` based upon the `X-Forwarded-For` header
