### PR TITLE
Operation Endpoints

### DIFF
--- a/actions_ledger.go
+++ b/actions_ledger.go
@@ -1,6 +1,7 @@
 package horizon
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/jagregory/halgo"
 	"github.com/stellar/go-horizon/db"
@@ -14,13 +15,13 @@ import (
 
 type LedgerResource struct {
 	halgo.Links
-	Id               string    `json:"id"`
-	Hash             string    `json:"hash"`
-	PrevHash         string    `json:"prev_hash"`
-	Sequence         int32     `json:"sequence"`
-	TransactionCount int32     `json:"transaction_count"`
-	OperationCount   int32     `json:"operation_count"`
-	ClosedAt         time.Time `json:"closed_at"`
+	Id               string         `json:"id"`
+	Hash             string         `json:"hash"`
+	PrevHash         sql.NullString `json:"prev_hash"`
+	Sequence         int32          `json:"sequence"`
+	TransactionCount int32          `json:"transaction_count"`
+	OperationCount   int32          `json:"operation_count"`
+	ClosedAt         time.Time      `json:"closed_at"`
 }
 
 func (l LedgerResource) SseData() interface{} { return l }

--- a/actions_operation.go
+++ b/actions_operation.go
@@ -1,0 +1,61 @@
+package horizon
+
+import (
+	"fmt"
+	"github.com/jagregory/halgo"
+	"github.com/stellar/go-horizon/db"
+	"github.com/stellar/go-horizon/render"
+	"github.com/stellar/go-horizon/render/problem"
+	"github.com/zenazn/goji/web"
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+type OperationResource struct {
+	halgo.Links
+	Id          int64  `json:"id"`
+	PagingToken string `json:"paging_token"`
+}
+
+func (r OperationResource) SseData() interface{} { return r }
+func (r OperationResource) Err() error           { return nil }
+func (r OperationResource) SseId() string        { return r.PagingToken }
+
+func operationIndexAction(c web.C, w http.ResponseWriter, r *http.Request) {
+	ah := &ActionHelper{c: c, r: r}
+	app := ah.App()
+
+	q := db.OperationPageQuery{
+		app.HistoryQuery(),
+		ah.GetPageQuery(),
+		ah.GetString("account_id"),
+		ah.GetInt32("ledger_id"),
+		ah.GetString("tx_id"),
+	}
+
+	if ah.Err() != nil {
+		problem.Render(context.TODO(), w, problem.ServerError)
+		return
+	}
+
+	render.Collection(w, r, q, operationRecordToResource)
+}
+
+func operationRecordToResource(record db.Record) (render.Resource, error) {
+	op := record.(db.OperationRecord)
+	self := fmt.Sprintf("/operations/%s", op.Id)
+	po := "{?cursor}{?limit}{?order}"
+
+	resource := OperationResource{
+		Links: halgo.Links{}.
+			Self(self).
+			Link("transactions", "/transactions/%s", op.TransactionId).
+			Link("effects", "%s/effects/%s", self, po).
+			Link("precedes", "/operations?cursor=%d&order=asc", op.PagingToken()).
+			Link("succeeds", "/operations?cursor=%d&order=desc", op.PagingToken()),
+		Id:          op.Id,
+		PagingToken: op.PagingToken(),
+	}
+
+	return resource, nil
+}

--- a/actions_operation_test.go
+++ b/actions_operation_test.go
@@ -1,0 +1,62 @@
+package horizon
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/go-horizon/test"
+	"testing"
+)
+
+func TestOperationActions(t *testing.T) {
+	test.LoadScenario("base")
+	app := NewTestApp()
+	defer app.Cancel()
+	rh := NewRequestHelper(app)
+
+	Convey("Operation Actions:", t, func() {
+
+		Convey("GET /operations", func() {
+			w := rh.Get("/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 4)
+		})
+
+		Convey("GET /ledgers/:ledger_id/operations", func() {
+			w := rh.Get("/ledgers/2/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 0)
+
+			w = rh.Get("/ledgers/3/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 3)
+
+			w = rh.Get("/ledgers/4/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+		})
+
+		Convey("GET /accounts/:account_id/operations", func() {
+			w := rh.Get("/accounts/gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 3)
+
+			w = rh.Get("/accounts/gT9jHoPKoErFwXavCrDYLkSVcVd9oyVv94ydrq6FnPMXpKHPTA/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+
+			w = rh.Get("/accounts/gsKuurNYgtBhTSFfsCaWqNb3Ze5Je9csKTSLfjo8Ko2b1f66ayZ/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 2)
+		})
+
+		Convey("GET /transactions/:tx_id/operations", func() {
+			w := rh.Get("/transactions/b313ee4b54d033eafd6bdc9c998b6ee8dbfe814da491b9182de8b63508e31369/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+
+			w = rh.Get("/transactions/83a428d46410a6699dee11c6785cb48ff62c5e403c2bf90efa2dbe862a9b33ab/operations", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+		})
+
+	})
+}

--- a/actions_transaction.go
+++ b/actions_transaction.go
@@ -67,7 +67,7 @@ func transactionShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := db.TransactionByHashQuery{
-		app.HistoryQuery(),
+		db.SqlQuery{app.HistoryQuery().DB.DB()},
 		hash,
 	}
 

--- a/actions_transaction.go
+++ b/actions_transaction.go
@@ -67,7 +67,7 @@ func transactionShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := db.TransactionByHashQuery{
-		db.SqlQuery{app.HistoryQuery().DB.DB()},
+		app.HistoryQuery(),
 		hash,
 	}
 

--- a/actions_transaction_test.go
+++ b/actions_transaction_test.go
@@ -31,19 +31,37 @@ func TestTransactionActions(t *testing.T) {
 		})
 
 		Convey("GET /transactions", func() {
-
 			w := rh.Get("/transactions", test.RequestHelperNoop)
-
-			var result map[string]interface{}
-			err := json.Unmarshal(w.Body.Bytes(), &result)
-			So(err, ShouldBeNil)
 			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 4)
+		})
 
-			embedded := result["_embedded"].(map[string]interface{})
-			records := embedded["records"].([]interface{})
+		Convey("GET /ledgers/:ledger_id/transactions", func() {
+			w := rh.Get("/ledgers/2/transactions", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 0)
 
-			So(len(records), ShouldEqual, 4)
+			w = rh.Get("/ledgers/3/transactions", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 3)
 
+			w = rh.Get("/ledgers/4/transactions", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+		})
+
+		Convey("GET /accounts/:account_od/transactions", func() {
+			w := rh.Get("/accounts/gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC/transactions", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 3)
+
+			w = rh.Get("/accounts/gT9jHoPKoErFwXavCrDYLkSVcVd9oyVv94ydrq6FnPMXpKHPTA/transactions", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+
+			w = rh.Get("/accounts/gsKuurNYgtBhTSFfsCaWqNb3Ze5Je9csKTSLfjo8Ko2b1f66ayZ/transactions", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 2)
 		})
 
 	})

--- a/app.go
+++ b/app.go
@@ -1,9 +1,9 @@
 package horizon
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/garyburd/redigo/redis"
-	"github.com/jinzhu/gorm"
 	"github.com/rcrowley/go-metrics"
 	"github.com/stellar/go-horizon/db"
 	"github.com/zenazn/goji/bind"
@@ -17,8 +17,8 @@ type App struct {
 	config    Config
 	metrics   metrics.Registry
 	web       *Web
-	historyDb gorm.DB
-	coreDb    gorm.DB
+	historyDb *sql.DB
+	coreDb    *sql.DB
 	ctx       context.Context
 	cancel    func()
 	redis     *redis.Pool
@@ -132,7 +132,7 @@ func (a *App) Serve() {
 	}
 
 	// initiate the ledger close pumper
-	db.LedgerClosePump(a.ctx, a.historyDb.DB())
+	db.LedgerClosePump(a.ctx, a.historyDb)
 
 	err := graceful.Serve(listener, http.DefaultServeMux)
 
@@ -149,14 +149,14 @@ func (a *App) Cancel() {
 	a.cancel()
 }
 
-// Returns a GormQuery that can be embedded in a parent query
+// Returns a SqlQuery that can be embedded in a parent query
 // to specify the query should run against the history database
-func (a *App) HistoryQuery() db.GormQuery {
-	return db.GormQuery{&a.historyDb}
+func (a *App) HistoryQuery() db.SqlQuery {
+	return db.SqlQuery{a.historyDb}
 }
 
-// Returns a GormQuery that can be embedded in a parent query
+// Returns a SqlQuery that can be embedded in a parent query
 // to specify the query should run against the connected stellar core database
-func (a *App) CoreQuery() db.GormQuery {
-	return db.GormQuery{&a.coreDb}
+func (a *App) CoreQuery() db.SqlQuery {
+	return db.SqlQuery{a.coreDb}
 }

--- a/db/doc.go
+++ b/db/doc.go
@@ -7,20 +7,18 @@
 // by address:
 //
 //    type AccountByAddress struct {
-//      GormQuery
+//      SqlQuery
 //      Address string
 //    }
 //
 // You would then implement the query's execution like so:
 //
-//    func (q AccountByAddress) Get() ([]interface{}, error) {
-//      var account Account
-//      err := q.GormQuery.DB.Where("address = ?", q.Address).First(&account).Error
-//      if err != nil {
-//        return nil, err
-//      }
+//    func (q CoreAccountByAddressQuery) Get() ([]interface{}, error) {
+//      sql := CoreAccountRecordSelect.Where("accountid = ?", q.Address).Limit(1)
 //
-//      return []interface{}{account}, nil
+//      var records []CoreAccountRecord
+//      err := q.SqlQuery.Select(sql, &records)
+//      return makeResult(records), err
 //    }
 //
 // Executing queries happens through `db.Results()`, `db.First()`, and

--- a/db/helpers_test.go
+++ b/db/helpers_test.go
@@ -1,9 +1,11 @@
 package db
 
 import (
+	"fmt"
 	"github.com/jinzhu/gorm"
 	"github.com/stellar/go-horizon/test"
 	"log"
+	"math"
 )
 
 func OpenTestDatabase() gorm.DB {
@@ -28,8 +30,47 @@ func OpenStellarCoreTestDatabase() gorm.DB {
 	return result
 }
 
+func ShouldBeOrderedAscending(actual interface{}, options ...interface{}) string {
+	records := actual.([]interface{})
+	t := options[0].(func(interface{}) int64)
+
+	prev := int64(0)
+
+	for i, r := range records {
+		cur := t(r)
+
+		if cur <= prev {
+			return fmt.Sprintf("not ordered ascending: idx:%s has order %d, which is less than the previous:%d", i, cur, prev)
+		}
+
+		prev = cur
+	}
+
+	return ""
+}
+
+func ShouldBeOrderedDescending(actual interface{}, options ...interface{}) string {
+	records := actual.([]interface{})
+	t := options[0].(func(interface{}) int64)
+
+	prev := int64(math.MaxInt64)
+
+	for i, r := range records {
+		cur := t(r)
+
+		if cur >= prev {
+			return fmt.Sprintf("not ordered decending: idx:%s has order %d, which is more than the previous:%d", i, cur, prev)
+		}
+
+		prev = cur
+	}
+
+	return ""
+}
+
+// Mock Dump Query
+
 type mockDumpQuery struct{}
-type mockStreamedQuery struct{}
 
 func (q mockDumpQuery) Get() ([]interface{}, error) {
 	return []interface{}{
@@ -43,6 +84,8 @@ func (q mockDumpQuery) Get() ([]interface{}, error) {
 func (q mockDumpQuery) IsComplete(alreadyDelivered int) bool {
 	return alreadyDelivered >= 4
 }
+
+// Mock Query
 
 type mockQuery struct {
 	resultCount int
@@ -66,6 +109,8 @@ func (q mockQuery) IsComplete(alreadyDelivered int) bool {
 	return alreadyDelivered >= q.resultCount
 }
 
+// Broken Query
+
 type BrokenQuery struct {
 	Err error
 }
@@ -76,24 +121,4 @@ func (q BrokenQuery) Get() ([]interface{}, error) {
 
 func (q BrokenQuery) IsComplete(alreadyDelivered int) bool {
 	return alreadyDelivered > 0
-}
-
-func MustFirst(q Query) interface{} {
-	result, err := First(q)
-
-	if err != nil {
-		panic(err)
-	}
-
-	return result
-}
-
-func MustResults(q Query) []interface{} {
-	result, err := Results(q)
-
-	if err != nil {
-		panic(err)
-	}
-
-	return result
 }

--- a/db/helpers_test.go
+++ b/db/helpers_test.go
@@ -1,32 +1,30 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
-	"github.com/jinzhu/gorm"
 	"github.com/stellar/go-horizon/test"
 	"log"
 	"math"
 )
 
-func OpenTestDatabase() gorm.DB {
+func OpenTestDatabase() *sql.DB {
 
-	result, err := gorm.Open("postgres", test.DatabaseUrl())
+	result, err := sql.Open("postgres", test.DatabaseUrl())
 
 	if err != nil {
 		log.Panic(err)
 	}
-	result.LogMode(true)
 	return result
 }
 
-func OpenStellarCoreTestDatabase() gorm.DB {
+func OpenStellarCoreTestDatabase() *sql.DB {
 
-	result, err := gorm.Open("postgres", test.StellarCoreDatabaseUrl())
+	result, err := sql.Open("postgres", test.StellarCoreDatabaseUrl())
 
 	if err != nil {
 		log.Panic(err)
 	}
-	result.LogMode(true)
 	return result
 }
 

--- a/db/main.go
+++ b/db/main.go
@@ -1,19 +1,15 @@
 package db
 
 import (
-	"database/sql"
 	"errors"
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
 	"github.com/rcrowley/go-metrics"
+	"reflect"
 )
 
 type GormQuery struct {
 	DB *gorm.DB
-}
-
-type SqlQuery struct {
-	DB *sql.DB
 }
 
 type Query interface {
@@ -95,8 +91,6 @@ func QueryGauge() metrics.Gauge {
 // helper method suited to confirm query validity.  checkOptions ensures
 // that zero or one of the provided bools ares true, but will return an error
 // if more than one clause is true.
-//
-
 func checkOptions(clauses ...bool) error {
 	hasOneSet := false
 
@@ -113,4 +107,17 @@ func checkOptions(clauses ...bool) error {
 	}
 
 	return nil
+}
+
+// Converts a typed slice to a slice of interface{}, suitable
+// for return through the Get() method of Query
+func makeResult(src interface{}) []interface{} {
+	srcValue := reflect.ValueOf(src)
+	srcLen := srcValue.Len()
+	result := make([]interface{}, srcLen)
+
+	for i := 0; i < srcLen; i++ {
+		result[i] = srcValue.Index(i).Interface()
+	}
+	return result
 }

--- a/db/main.go
+++ b/db/main.go
@@ -1,16 +1,12 @@
 package db
 
 import (
+	"database/sql"
 	"errors"
-	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
 	"github.com/rcrowley/go-metrics"
 	"reflect"
 )
-
-type GormQuery struct {
-	DB *gorm.DB
-}
 
 type Query interface {
 	Get() ([]interface{}, error)
@@ -25,15 +21,15 @@ type Record interface{}
 
 // Open the postgres database at the provided url and performing an initial
 // ping to ensure we can connect to it.
-func Open(url string) (gorm.DB, error) {
+func Open(url string) (*sql.DB, error) {
 
-	db, err := gorm.Open("postgres", url)
+	db, err := sql.Open("postgres", url)
 
 	if err != nil {
 		return db, err
 	}
 
-	err = db.DB().Ping()
+	err = db.Ping()
 
 	if err != nil {
 		return db, err
@@ -53,8 +49,6 @@ func First(query Query) (interface{}, error) {
 	res, err := query.Get()
 
 	switch {
-	case err == gorm.RecordNotFound:
-		return nil, nil
 	case err != nil:
 		return nil, err
 	case len(res) == 0:

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -49,7 +49,7 @@ func ExampleFirst() {
 	defer db.Close()
 
 	q := CoreAccountByAddressQuery{
-		SqlQuery{db.DB()},
+		SqlQuery{db},
 		"gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC",
 	}
 

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -46,8 +46,10 @@ func TestMain(t *testing.T) {
 
 func ExampleFirst() {
 	db := OpenStellarCoreTestDatabase()
+	defer db.Close()
+
 	q := CoreAccountByAddressQuery{
-		GormQuery{&db},
+		SqlQuery{db.DB()},
 		"gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC",
 	}
 

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	_ "github.com/lib/pq"
 	. "github.com/smartystreets/goconvey/convey"
+	"log"
 	"testing"
 )
 
@@ -41,4 +42,22 @@ func TestMain(t *testing.T) {
 			So(err.Error(), ShouldEqual, "Some error")
 		})
 	})
+}
+
+func ExampleFirst() {
+	db := OpenStellarCoreTestDatabase()
+	q := CoreAccountByAddressQuery{
+		GormQuery{&db},
+		"gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC",
+	}
+
+	record, err := First(q)
+
+	if err != nil {
+		panic(err)
+	}
+
+	account := record.(CoreAccountRecord)
+	log.Println(account.Accountid)
+
 }

--- a/db/query_account_by_address.go
+++ b/db/query_account_by_address.go
@@ -1,0 +1,18 @@
+package db
+
+type AccountByAddressQuery struct {
+	SqlQuery
+	Address string
+}
+
+func (q AccountByAddressQuery) Get() ([]interface{}, error) {
+	sql := AccountRecordSelect.Where("address = ?", q.Address).Limit(1)
+
+	var records []AccountRecord
+	err := q.SqlQuery.Select(sql, &records)
+	return makeResult(records), err
+}
+
+func (q AccountByAddressQuery) IsComplete(alreadyDelivered int) bool {
+	return alreadyDelivered > 0
+}

--- a/db/query_account_by_address_test.go
+++ b/db/query_account_by_address_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	_ "github.com/lib/pq"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/go-horizon/test"
+	"testing"
+)
+
+func TestAccountByAddressQuery(t *testing.T) {
+	test.LoadScenario("base")
+	db := OpenTestDatabase()
+	defer db.Close()
+
+	Convey("AccountByAddress", t, func() {
+
+		Convey("Existing record behavior", func() {
+			address := "gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC"
+			q := AccountByAddressQuery{
+				SqlQuery{db},
+				address,
+			}
+			result, err := First(q)
+			So(err, ShouldBeNil)
+			account := result.(AccountRecord)
+
+			So(account.Id, ShouldEqual, 0)
+			So(account.Address, ShouldEqual, address)
+		})
+
+		Convey("Missing record behavior", func() {
+			address := "not real"
+			q := AccountByAddressQuery{
+				SqlQuery{db},
+				address,
+			}
+			result, err := First(q)
+			So(result, ShouldBeNil)
+			So(err, ShouldBeNil)
+		})
+
+	})
+}

--- a/db/query_core_account_by_address.go
+++ b/db/query_core_account_by_address.go
@@ -1,14 +1,16 @@
 package db
 
 type CoreAccountByAddressQuery struct {
-	GormQuery
+	SqlQuery
 	Address string
 }
 
 func (q CoreAccountByAddressQuery) Get() ([]interface{}, error) {
-	var account CoreAccountRecord
-	err := q.GormQuery.DB.Where("accountid = ?", q.Address).First(&account).Error
-	return []interface{}{account}, err
+	sql := CoreAccountRecordSelect.Where("accountid = ?", q.Address).Limit(1)
+
+	var records []CoreAccountRecord
+	err := q.SqlQuery.Select(sql, &records)
+	return makeResult(records), err
 }
 
 func (q CoreAccountByAddressQuery) IsComplete(alreadyDelivered int) bool {

--- a/db/query_core_account_by_address_test.go
+++ b/db/query_core_account_by_address_test.go
@@ -12,14 +12,16 @@ func TestCoreAccountByAddressQuery(t *testing.T) {
 	Convey("CoreAccountByAddress", t, func() {
 		test.LoadScenario("base")
 		db := OpenStellarCoreTestDatabase()
+		defer db.Close()
 
 		Convey("Existing record behavior", func() {
 			address := "gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC"
 			q := CoreAccountByAddressQuery{
-				GormQuery{&db},
+				SqlQuery{db.DB()},
 				address,
 			}
-			result, _ := First(q)
+			result, err := First(q)
+			So(err, ShouldBeNil)
 			account := result.(CoreAccountRecord)
 
 			So(account.Accountid, ShouldEqual, address)
@@ -29,7 +31,7 @@ func TestCoreAccountByAddressQuery(t *testing.T) {
 		Convey("Missing record behavior", func() {
 			address := "not real"
 			q := CoreAccountByAddressQuery{
-				GormQuery{&db},
+				SqlQuery{db.DB()},
 				address,
 			}
 			result, err := First(q)

--- a/db/query_core_account_by_address_test.go
+++ b/db/query_core_account_by_address_test.go
@@ -17,7 +17,7 @@ func TestCoreAccountByAddressQuery(t *testing.T) {
 		Convey("Existing record behavior", func() {
 			address := "gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC"
 			q := CoreAccountByAddressQuery{
-				SqlQuery{db.DB()},
+				SqlQuery{db},
 				address,
 			}
 			result, err := First(q)
@@ -31,7 +31,7 @@ func TestCoreAccountByAddressQuery(t *testing.T) {
 		Convey("Missing record behavior", func() {
 			address := "not real"
 			q := CoreAccountByAddressQuery{
-				SqlQuery{db.DB()},
+				SqlQuery{db},
 				address,
 			}
 			result, err := First(q)

--- a/db/query_ledger_by_sequence.go
+++ b/db/query_ledger_by_sequence.go
@@ -1,24 +1,16 @@
 package db
 
 type LedgerBySequenceQuery struct {
-	GormQuery
+	SqlQuery
 	Sequence int32
 }
 
-func (l LedgerBySequenceQuery) Get() ([]interface{}, error) {
-	var ledgers []LedgerRecord
-	err := l.GormQuery.DB.Where("sequence = ?", l.Sequence).Find(&ledgers).Error
+func (q LedgerBySequenceQuery) Get() ([]interface{}, error) {
+	sql := LedgerRecordSelect.Where("sequence = ?", q.Sequence).Limit(1)
 
-	if err != nil {
-		return nil, err
-	}
-
-	results := make([]interface{}, len(ledgers))
-	for i := range ledgers {
-		results[i] = ledgers[i]
-	}
-
-	return results, nil
+	var records []LedgerRecord
+	err := q.SqlQuery.Select(sql, &records)
+	return makeResult(records), err
 }
 
 func (l LedgerBySequenceQuery) IsComplete(alreadyDelivered int) bool {

--- a/db/query_ledger_by_sequence_test.go
+++ b/db/query_ledger_by_sequence_test.go
@@ -17,7 +17,7 @@ func TestLedgerBySequenceQuery(t *testing.T) {
 		Convey("Existing record behavior", func() {
 			sequence := int32(2)
 			q := LedgerBySequenceQuery{
-				GormQuery{&db},
+				SqlQuery{db.DB()},
 				sequence,
 			}
 			ledgers, err := Results(q)
@@ -32,7 +32,7 @@ func TestLedgerBySequenceQuery(t *testing.T) {
 		Convey("Missing record behavior", func() {
 			sequence := int32(-1)
 			var q Query = LedgerBySequenceQuery{
-				GormQuery{&db},
+				SqlQuery{db.DB()},
 				sequence,
 			}
 			ledgers, err := Results(q)

--- a/db/query_ledger_by_sequence_test.go
+++ b/db/query_ledger_by_sequence_test.go
@@ -17,7 +17,7 @@ func TestLedgerBySequenceQuery(t *testing.T) {
 		Convey("Existing record behavior", func() {
 			sequence := int32(2)
 			q := LedgerBySequenceQuery{
-				SqlQuery{db.DB()},
+				SqlQuery{db},
 				sequence,
 			}
 			ledgers, err := Results(q)
@@ -32,7 +32,7 @@ func TestLedgerBySequenceQuery(t *testing.T) {
 		Convey("Missing record behavior", func() {
 			sequence := int32(-1)
 			var q Query = LedgerBySequenceQuery{
-				SqlQuery{db.DB()},
+				SqlQuery{db},
 				sequence,
 			}
 			ledgers, err := Results(q)

--- a/db/query_ledger_page_test.go
+++ b/db/query_ledger_page_test.go
@@ -17,7 +17,7 @@ func TestLedgerPageQuery(t *testing.T) {
 		pq, err := NewPageQuery("0", "asc", 3)
 		So(err, ShouldBeNil)
 
-		q := LedgerPageQuery{SqlQuery{db.DB()}, pq}
+		q := LedgerPageQuery{SqlQuery{db}, pq}
 		ledgers, err := Results(q)
 
 		So(err, ShouldBeNil)

--- a/db/query_ledger_page_test.go
+++ b/db/query_ledger_page_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 func TestLedgerPageQuery(t *testing.T) {
+	test.LoadScenario("base")
+	db := OpenTestDatabase()
+	defer db.Close()
 
 	Convey("LedgerPageQuery", t, func() {
-		test.LoadScenario("base")
-		db := OpenTestDatabase()
 		pq, err := NewPageQuery("0", "asc", 3)
 		So(err, ShouldBeNil)
 

--- a/db/query_ledger_page_test.go
+++ b/db/query_ledger_page_test.go
@@ -17,7 +17,7 @@ func TestLedgerPageQuery(t *testing.T) {
 		pq, err := NewPageQuery("0", "asc", 3)
 		So(err, ShouldBeNil)
 
-		q := LedgerPageQuery{GormQuery{&db}, pq}
+		q := LedgerPageQuery{SqlQuery{db.DB()}, pq}
 		ledgers, err := Results(q)
 
 		So(err, ShouldBeNil)

--- a/db/query_operation_page.go
+++ b/db/query_operation_page.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"errors"
+	sq "github.com/lann/squirrel"
+)
+
+type OperationPageQuery struct {
+	SqlQuery
+	PageQuery
+	AccountAddress  string
+	LedgerSequence  int32
+	TransactionHash string
+}
+
+func (q OperationPageQuery) Get() (results []interface{}, err error) {
+	sql := OperationRecordSelect.
+		Limit(uint64(q.Limit)).
+		PlaceholderFormat(sq.Dollar).
+		RunWith(q.DB)
+
+	switch q.Order {
+	case "asc":
+		sql = sql.Where("hop.id > ?", q.Cursor).OrderBy("hop.id asc")
+	case "desc":
+		sql = sql.Where("hop.id < ?", q.Cursor).OrderBy("hop.id desc")
+	}
+
+	err = checkOptions(
+		q.AccountAddress != "",
+		q.LedgerSequence != 0,
+		q.TransactionHash != "",
+	)
+
+	if err != nil {
+		return
+	}
+
+	// filter by ledger sequence
+	if q.LedgerSequence != 0 {
+		start := TotalOrderId{LedgerSequence: q.LedgerSequence}
+		end := TotalOrderId{LedgerSequence: q.LedgerSequence + 1}
+		sql = sql.Where("hop.id >= ? AND hop.id < ?", start.ToInt64(), end.ToInt64())
+	}
+
+	// filter by transaction hash
+	if q.TransactionHash != "" {
+		var record interface{}
+		record, err = First(TransactionByHashQuery{q.SqlQuery, q.TransactionHash})
+
+		if err != nil {
+			return
+		}
+
+		if record == nil {
+			err = errors.New("Bad transaction hash") //TODO: improvements
+			return
+		}
+
+		tx := record.(TransactionRecord)
+
+		start := ParseTotalOrderId(tx.Id)
+		end := start
+		end.TransactionOrder++
+		sql = sql.Where("hop.id >= ? AND hop.id < ?", start.ToInt64(), end.ToInt64())
+	}
+
+	// filter by account address
+	if q.AccountAddress != "" {
+		//TODO
+	}
+
+	rows, err := sql.Query()
+	if err != nil {
+		return
+	}
+
+	defer rows.Close()
+
+	results = []interface{}{}
+	for rows.Next() {
+		record := &OperationRecord{}
+		err = record.ScanFrom(rows)
+
+		if err != nil {
+			return
+		}
+
+		results = append(results, *record)
+	}
+
+	return
+}
+
+func (q OperationPageQuery) IsComplete(alreadyDelivered int) bool {
+	return alreadyDelivered >= int(q.Limit)
+}

--- a/db/query_operation_page.go
+++ b/db/query_operation_page.go
@@ -70,25 +70,9 @@ func (q OperationPageQuery) Get() (results []interface{}, err error) {
 		//TODO
 	}
 
-	rows, err := sql.Query()
-	if err != nil {
-		return
-	}
-
-	defer rows.Close()
-
-	results = []interface{}{}
-	for rows.Next() {
-		record := &OperationRecord{}
-		err = record.ScanFrom(rows)
-
-		if err != nil {
-			return
-		}
-
-		results = append(results, *record)
-	}
-
+	var records []OperationRecord
+	err = q.SqlQuery.Select(sql, &records)
+	results = makeResult(records)
 	return
 }
 

--- a/db/query_operation_page_test.go
+++ b/db/query_operation_page_test.go
@@ -1,0 +1,131 @@
+package db
+
+import (
+	_ "github.com/lib/pq"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/go-horizon/test"
+	"testing"
+)
+
+func TestOperationPageQuery(t *testing.T) {
+	Convey("OperationPageQuery", t, func() {
+		test.LoadScenario("base")
+		db := OpenTestDatabase()
+		defer db.Close()
+
+		makeQuery := func(c string, o string, l int32) OperationPageQuery {
+			pq, err := NewPageQuery(c, o, l)
+
+			So(err, ShouldBeNil)
+
+			return OperationPageQuery{
+				SqlQuery:  SqlQuery{db.DB()},
+				PageQuery: pq,
+			}
+		}
+
+		Convey("orders properly", func() {
+			// asc orders ascending by id
+			records := MustResults(makeQuery("", "asc", 0))
+			So(records, ShouldBeOrderedAscending, func(r interface{}) int64 {
+				So(r, ShouldHaveSameTypeAs, OperationRecord{})
+				return r.(OperationRecord).Id
+			})
+
+			// desc orders descending by id
+			records = MustResults(makeQuery("", "desc", 0))
+			So(records, ShouldBeOrderedDescending, func(r interface{}) int64 {
+				So(r, ShouldHaveSameTypeAs, OperationRecord{})
+				return r.(OperationRecord).Id
+			})
+		})
+
+		Convey("limits properly", func() {
+			// returns number specified
+			records := MustResults(makeQuery("", "asc", 3))
+			So(len(records), ShouldEqual, 3)
+
+			// returns all rows if limit is higher
+			records = MustResults(makeQuery("", "asc", 10))
+			So(len(records), ShouldEqual, 4)
+		})
+
+		Convey("cursor works properly", func() {
+			// lowest id if ordered ascending and no cursor
+			record := MustFirst(makeQuery("", "asc", 0))
+			So(record.(OperationRecord).Id, ShouldEqual, 12884905984)
+
+			// highest id if ordered descending and no cursor
+			record = MustFirst(makeQuery("", "desc", 0))
+			So(record.(OperationRecord).Id, ShouldEqual, 17179873280)
+
+			// starts after the cursor if ordered ascending
+			record = MustFirst(makeQuery("12884905984", "asc", 0))
+			So(record.(OperationRecord).Id, ShouldEqual, 12884910080)
+
+			// starts before the cursor if ordered descending
+			record = MustFirst(makeQuery("17179873280", "desc", 0))
+			So(record.(OperationRecord).Id, ShouldEqual, 12884914176)
+		})
+
+		Convey("restricts to address properly", func() {
+			address := "gqdUHrgHUp8uMb74HiQvYztze2ffLhVXpPwj7gEZiJRa4jhCXQ"
+			q := makeQuery("", "asc", 0)
+			q.AccountAddress = address
+			r := MustResults(q)
+
+			So(len(r), ShouldEqual, 2)
+			So(r[0].(OperationRecord).Id, ShouldEqual, 12884914176)
+			So(r[1].(OperationRecord).Id, ShouldEqual, 17179873280)
+		})
+
+		Convey("restricts to ledger properly", func() {
+			q := makeQuery("", "asc", 0)
+			q.LedgerSequence = 3
+			records := MustResults(q)
+
+			So(len(records), ShouldEqual, 3)
+
+			for _, r := range records {
+				toid := ParseTotalOrderId(r.(OperationRecord).TransactionId)
+				So(toid.LedgerSequence, ShouldEqual, 3)
+			}
+		})
+
+		Convey("restricts to transaction properly", func() {
+			q := makeQuery("", "asc", 0)
+			q.TransactionHash = "b313ee4b54d033eafd6bdc9c998b6ee8dbfe814da491b9182de8b63508e31369"
+			records := MustResults(q)
+
+			So(len(records), ShouldEqual, 1)
+
+			for _, r := range records {
+				So(r.(OperationRecord).TransactionId, ShouldEqual, 12884905984)
+			}
+		})
+
+		Convey("errors if more than one filter is supplied", func() {
+			table := []struct {
+				Hash    string
+				Ledger  int32
+				Address string
+			}{
+				{"1", 1, "1"},
+				{"", 1, "1"},
+				{"1", 1, ""},
+				{"1", 0, "1"},
+			}
+
+			for _, o := range table {
+				q := makeQuery("", "asc", 0)
+				q.TransactionHash = o.Hash
+				q.LedgerSequence = o.Ledger
+				q.AccountAddress = o.Address
+
+				_, err := Results(q)
+				So(err, ShouldNotBeNil)
+			}
+
+		})
+	})
+}

--- a/db/query_operation_page_test.go
+++ b/db/query_operation_page_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestOperationPageQuery(t *testing.T) {
-	Convey("OperationPageQuery", t, func() {
-		test.LoadScenario("base")
-		db := OpenTestDatabase()
-		defer db.Close()
+	test.LoadScenario("base")
+	db := OpenTestDatabase()
+	defer db.Close()
 
+	Convey("OperationPageQuery", t, func() {
 		makeQuery := func(c string, o string, l int32) OperationPageQuery {
 			pq, err := NewPageQuery(c, o, l)
 

--- a/db/query_operation_page_test.go
+++ b/db/query_operation_page_test.go
@@ -19,7 +19,7 @@ func TestOperationPageQuery(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			return OperationPageQuery{
-				SqlQuery:  SqlQuery{db.DB()},
+				SqlQuery:  SqlQuery{db},
 				PageQuery: pq,
 			}
 		}

--- a/db/query_sql.go
+++ b/db/query_sql.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"database/sql"
+	"github.com/jmoiron/sqlx"
+	sq "github.com/lann/squirrel"
+)
+
+type SqlQuery struct {
+	DB *sql.DB
+}
+
+func (q SqlQuery) Select(sql sq.SelectBuilder, dest interface{}) error {
+	db := sqlx.NewDb(q.DB, "postgres")
+	sql = sql.PlaceholderFormat(sq.Dollar)
+	query, args, err := sql.ToSql()
+
+	if err != nil {
+		return err
+	}
+
+	return db.Select(dest, query, args...)
+}

--- a/db/query_transaction_by_hash_test.go
+++ b/db/query_transaction_by_hash_test.go
@@ -16,7 +16,7 @@ func TestTransactionByHashQuery(t *testing.T) {
 
 		Convey("Existing record behavior", func() {
 			hash := "b313ee4b54d033eafd6bdc9c998b6ee8dbfe814da491b9182de8b63508e31369"
-			q := TransactionByHashQuery{SqlQuery{db.DB()}, hash}
+			q := TransactionByHashQuery{SqlQuery{db}, hash}
 			found, err := First(q)
 			So(err, ShouldBeNil)
 			tx := found.(TransactionRecord)
@@ -25,7 +25,7 @@ func TestTransactionByHashQuery(t *testing.T) {
 
 		Convey("Missing record behavior", func() {
 			hash := "not_real"
-			q := TransactionByHashQuery{SqlQuery{db.DB()}, hash}
+			q := TransactionByHashQuery{SqlQuery{db}, hash}
 			found, err := First(q)
 			So(err, ShouldBeNil)
 			So(found, ShouldBeNil)

--- a/db/query_transaction_by_hash_test.go
+++ b/db/query_transaction_by_hash_test.go
@@ -16,7 +16,7 @@ func TestTransactionByHashQuery(t *testing.T) {
 
 		Convey("Existing record behavior", func() {
 			hash := "b313ee4b54d033eafd6bdc9c998b6ee8dbfe814da491b9182de8b63508e31369"
-			q := TransactionByHashQuery{GormQuery{&db}, hash}
+			q := TransactionByHashQuery{SqlQuery{db.DB()}, hash}
 			found, err := First(q)
 			So(err, ShouldBeNil)
 			tx := found.(TransactionRecord)
@@ -25,7 +25,7 @@ func TestTransactionByHashQuery(t *testing.T) {
 
 		Convey("Missing record behavior", func() {
 			hash := "not_real"
-			q := TransactionByHashQuery{GormQuery{&db}, hash}
+			q := TransactionByHashQuery{SqlQuery{db.DB()}, hash}
 			found, err := First(q)
 			So(err, ShouldBeNil)
 			So(found, ShouldBeNil)

--- a/db/query_transaction_page_test.go
+++ b/db/query_transaction_page_test.go
@@ -19,7 +19,7 @@ func TestTransactionPageQuery(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			return TransactionPageQuery{
-				SqlQuery:  SqlQuery{db.DB()},
+				SqlQuery:  SqlQuery{db},
 				PageQuery: pq,
 			}
 		}

--- a/db/query_transaction_page_test.go
+++ b/db/query_transaction_page_test.go
@@ -19,7 +19,7 @@ func TestTransactionPageQuery(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			return TransactionPageQuery{
-				GormQuery: GormQuery{&db},
+				SqlQuery:  SqlQuery{db.DB()},
 				PageQuery: pq,
 			}
 		}

--- a/db/query_transaction_page_test.go
+++ b/db/query_transaction_page_test.go
@@ -4,7 +4,6 @@ import (
 	_ "github.com/lib/pq"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stellar/go-horizon/test"
-	"math"
 	"testing"
 )
 
@@ -28,25 +27,19 @@ func TestTransactionPageQuery(t *testing.T) {
 		Convey("orders properly", func() {
 			// asc orders ascending by id
 			records := MustResults(makeQuery("", "asc", 0))
-			cur := int64(0)
 
-			for _, r := range records {
+			So(records, ShouldBeOrderedAscending, func(r interface{}) int64 {
 				So(r, ShouldHaveSameTypeAs, TransactionRecord{})
-				id := r.(TransactionRecord).Id
-				So(id, ShouldBeGreaterThan, cur)
-				cur = id
-			}
+				return r.(TransactionRecord).Id
+			})
 
 			// desc orders descending by id
 			records = MustResults(makeQuery("", "desc", 0))
-			cur = math.MaxInt64
 
-			for _, r := range records {
+			So(records, ShouldBeOrderedDescending, func(r interface{}) int64 {
 				So(r, ShouldHaveSameTypeAs, TransactionRecord{})
-				id := r.(TransactionRecord).Id
-				So(id, ShouldBeLessThan, cur)
-				cur = id
-			}
+				return r.(TransactionRecord).Id
+			})
 		})
 
 		Convey("limits properly", func() {

--- a/db/record_account.go
+++ b/db/record_account.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"fmt"
+	sq "github.com/lann/squirrel"
+)
+
+var AccountRecordSelect sq.SelectBuilder = sq.
+	Select("ha.*").
+	From("history_accounts ha")
+
+type AccountRecord struct {
+	Id      int64  `db:"id"`
+	Address string `db:"address"`
+}
+
+func (r AccountRecord) PagingToken() string {
+	return fmt.Sprintf("%d", r.Id)
+}

--- a/db/record_core_account.go
+++ b/db/record_core_account.go
@@ -1,16 +1,27 @@
 package db
 
+import (
+	"database/sql"
+	sq "github.com/lann/squirrel"
+)
+
+var CoreAccountRecordSelect sq.SelectBuilder = sq.Select(
+	"a.accountid",
+	"a.balance",
+	"a.seqnum",
+	"a.numsubentries",
+	"a.inflationdest",
+	"a.thresholds",
+	"a.flags",
+).From("accounts a")
+
 // A row of data from the `accounts` table from stellar-core
 type CoreAccountRecord struct {
 	Accountid     string
 	Balance       int64
 	Seqnum        int64
 	Numsubentries int32
-	Inflationdest string
+	Inflationdest sql.NullString
 	Thresholds    string
 	Flags         int32
-}
-
-func (r CoreAccountRecord) TableName() string {
-	return "accounts"
 }

--- a/db/record_ledger.go
+++ b/db/record_ledger.go
@@ -1,24 +1,26 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
+	sq "github.com/lann/squirrel"
 	"time"
 )
 
-type LedgerRecord struct {
-	Id                 int64
-	Sequence           int32
-	LedgerHash         string
-	PreviousLedgerHash string
-	TransactionCount   int32
-	OperationCount     int32
-	ClosedAt           time.Time
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
-}
+var LedgerRecordSelect sq.SelectBuilder = sq.
+	Select("hl.*").
+	From("history_ledgers hl")
 
-func (r LedgerRecord) TableName() string {
-	return "history_ledgers"
+type LedgerRecord struct {
+	Id                 int64          `db:"id"`
+	Sequence           int32          `db:"sequence"`
+	LedgerHash         string         `db:"ledger_hash"`
+	PreviousLedgerHash sql.NullString `db:"previous_ledger_hash"`
+	TransactionCount   int32          `db:"transaction_count"`
+	OperationCount     int32          `db:"operation_count"`
+	ClosedAt           time.Time      `db:"closed_at"`
+	CreatedAt          time.Time      `db:"created_at"`
+	UpdatedAt          time.Time      `db:"updated_at"`
 }
 
 func (r LedgerRecord) PagingToken() string {

--- a/db/record_operation.go
+++ b/db/record_operation.go
@@ -7,20 +7,16 @@ import (
 	"github.com/lib/pq/hstore"
 )
 
-var OperationRecordSelect squirrel.SelectBuilder = squirrel.Select(
-	"hop.id",
-	"hop.transaction_id",
-	"hop.application_order",
-	"hop.type",
-	"hop.details",
-).From("history_operations hop")
+var OperationRecordSelect squirrel.SelectBuilder = squirrel.
+	Select("hop.*").
+	From("history_operations hop")
 
 type OperationRecord struct {
-	Id               int64
-	TransactionId    int64
-	ApplicationOrder int32
-	Type             int32
-	Details          hstore.Hstore
+	Id               int64         `db:"id"`
+	TransactionId    int64         `db:"transaction_id"`
+	ApplicationOrder int32         `db:"application_order"`
+	Type             int32         `db:"type"`
+	Details          hstore.Hstore `db:"details"`
 }
 
 func (r OperationRecord) PagingToken() string {

--- a/db/record_operation.go
+++ b/db/record_operation.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/lann/squirrel"
+	"github.com/lib/pq/hstore"
+)
+
+var OperationRecordSelect squirrel.SelectBuilder = squirrel.Select(
+	"hop.id",
+	"hop.transaction_id",
+	"hop.application_order",
+	"hop.type",
+	"hop.details",
+).From("history_operations hop")
+
+type OperationRecord struct {
+	Id               int64
+	TransactionId    int64
+	ApplicationOrder int32
+	Type             int32
+	Details          hstore.Hstore
+}
+
+func (r OperationRecord) PagingToken() string {
+	return fmt.Sprintf("%d", r.Id)
+}
+
+func (r *OperationRecord) ScanFrom(rows *sql.Rows) error {
+	return rows.Scan(
+		&r.Id,
+		&r.TransactionId,
+		&r.ApplicationOrder,
+		&r.Type,
+		&r.Details,
+	)
+}

--- a/db/record_operation.go
+++ b/db/record_operation.go
@@ -1,13 +1,12 @@
 package db
 
 import (
-	"database/sql"
 	"fmt"
-	"github.com/lann/squirrel"
+	sq "github.com/lann/squirrel"
 	"github.com/lib/pq/hstore"
 )
 
-var OperationRecordSelect squirrel.SelectBuilder = squirrel.
+var OperationRecordSelect sq.SelectBuilder = sq.
 	Select("hop.*").
 	From("history_operations hop")
 
@@ -21,14 +20,4 @@ type OperationRecord struct {
 
 func (r OperationRecord) PagingToken() string {
 	return fmt.Sprintf("%d", r.Id)
-}
-
-func (r *OperationRecord) ScanFrom(rows *sql.Rows) error {
-	return rows.Scan(
-		&r.Id,
-		&r.TransactionId,
-		&r.ApplicationOrder,
-		&r.Type,
-		&r.Details,
-	)
 }

--- a/db/record_transaction.go
+++ b/db/record_transaction.go
@@ -1,38 +1,29 @@
 package db
 
 import (
-	"database/sql"
 	"fmt"
-	"github.com/lann/squirrel"
+	sq "github.com/lann/squirrel"
 	"time"
 )
 
 // Provides a squirrel.SelectBuilder upon which you may build actual queries.
-var TransactionRecordSelect squirrel.SelectBuilder = squirrel.Select(
-	"ht.id",
-	"ht.transaction_hash",
-	"ht.ledger_sequence",
-	"ht.application_order",
-	"ht.account",
-	"ht.account_sequence",
-	"ht.max_fee",
-	"ht.fee_paid",
-	"ht.operation_count",
-).From("history_transactions ht")
+var TransactionRecordSelect sq.SelectBuilder = sq.
+	Select("ht.*").
+	From("history_transactions ht")
 
 type TransactionRecord struct {
-	Id               int64
-	TransactionHash  string
-	LedgerSequence   int32
-	ApplicationOrder int32
-	Account          string
-	AccountSequence  int64
-	MaxFee           int32
-	FeePaid          int32
-	OperationCount   int32
-	ClosedAt         time.Time
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	Id                  int64     `db:"id"`
+	TransactionHash     string    `db:"transaction_hash"`
+	LedgerSequence      int32     `db:"ledger_sequence"`
+	ApplicationOrder    int32     `db:"application_order"`
+	Account             string    `db:"account"`
+	AccountSequence     int64     `db:"account_sequence"`
+	MaxFee              int32     `db:"max_fee"`
+	FeePaid             int32     `db:"fee_paid"`
+	OperationCount      int32     `db:"operation_count"`
+	TransactionStatusId int32     `db:"transaction_status_id"`
+	CreatedAt           time.Time `db:"created_at"`
+	UpdatedAt           time.Time `db:"updated_at"`
 }
 
 func (r TransactionRecord) TableName() string {
@@ -41,18 +32,4 @@ func (r TransactionRecord) TableName() string {
 
 func (r TransactionRecord) PagingToken() string {
 	return fmt.Sprintf("%d", r.Id)
-}
-
-func (r *TransactionRecord) ScanFrom(rows *sql.Rows) error {
-	return rows.Scan(
-		&r.Id,
-		&r.TransactionHash,
-		&r.LedgerSequence,
-		&r.ApplicationOrder,
-		&r.Account,
-		&r.AccountSequence,
-		&r.MaxFee,
-		&r.FeePaid,
-		&r.OperationCount,
-	)
 }

--- a/db/total_order_id.go
+++ b/db/total_order_id.go
@@ -1,0 +1,100 @@
+package db
+
+//
+// A TotalOrderId expressed the total order of Ledgers, Transactions and
+// Operations.
+//
+// Operations within the stellar network have a total order, expressed by three
+// pieces of information:  the ledger sequence the operation was validated in,
+// the order which the operation's containing transaction was applied in
+// that ledger, and the index of the operation within that parent transaction.
+//
+// We express this order by packing those three pieces of information into a
+// single signed 64-bit number (we used a signed number for SQL compatibility).
+//
+// The follow diagram shows this format:
+//
+//    0                   1                   2                   3
+//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |                    Ledger Sequence Number                     |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |     Transaction Application Order     |       Op Index        |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// By component:
+//
+// Ledger Sequence: 32-bits
+//
+//   A complete ledger sequence number in which the operation was validated.
+//
+//   Expressed in network byte order.
+//
+// Transaction Application Order: 20-bits
+//
+//   The order that the transaction was applied within the ledger it was
+//   validated.  Accommodates up to 1,048,575 transactions in a single ledger.
+//
+//   Expressed in network byte order.
+//
+// Operation Index: 10-bits
+//
+//   The index of the operation within its parent transaction. Accommodates up
+//   to 4095 operations per transaction.
+//
+//   Expressed in network byte order.
+//
+//
+// Note: API Clients should not be interpreting this value.  We will use it
+// as an opaque paging token that clients can parrot back to us after having read
+// it within a resource to page from the represented position in time.
+//
+// Note: This does not uniquely identify an object.  Given a ledger, it will
+// share its id with its first transaction and the first operation of that
+// transaction as well.  Given that this ID is only meant for ordering within a
+// single type of object, the sharing of ids across object types seems
+// acceptable.
+//
+type TotalOrderId struct {
+	LedgerSequence   int32
+	TransactionOrder int32
+	OperationOrder   int32
+}
+
+const (
+	TotalOrderLedgerMask      = (1 << 32) - 1
+	TotalOrderTransactionMask = (1 << 20) - 1
+	TotalOrderOperationMask   = (1 << 12) - 1
+
+	TotalOrderLedgerShift      = 32
+	TotalOrderTransactionShift = 12
+	TotalOrderOperationShift   = 0
+)
+
+func (id TotalOrderId) ToInt64() (result int64) {
+
+	if id.LedgerSequence < 0 {
+		panic("invalid ledger sequence")
+	}
+
+	if id.TransactionOrder > TotalOrderTransactionMask {
+		panic("transaction order overflow")
+	}
+
+	if id.OperationOrder > TotalOrderOperationMask {
+		panic("operation order overflow")
+	}
+
+	result = result | ((int64(id.LedgerSequence) & TotalOrderLedgerMask) << TotalOrderLedgerShift)
+	result = result | ((int64(id.TransactionOrder) & TotalOrderTransactionMask) << TotalOrderTransactionShift)
+	result = result | ((int64(id.OperationOrder) & TotalOrderOperationMask) << TotalOrderOperationShift)
+	return
+}
+
+func ParseTotalOrderId(id int64) (result TotalOrderId) {
+	result.LedgerSequence = int32((id >> TotalOrderLedgerShift) & TotalOrderLedgerMask)
+	result.TransactionOrder = int32((id >> TotalOrderTransactionShift) & TotalOrderTransactionMask)
+	result.OperationOrder = int32((id >> TotalOrderOperationShift) & TotalOrderOperationMask)
+
+	return
+}

--- a/db/total_order_id_test.go
+++ b/db/total_order_id_test.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"fmt"
+	_ "github.com/lib/pq"
+	. "github.com/smartystreets/goconvey/convey"
+	"math"
+	"testing"
+)
+
+func TestTotalOrderId(t *testing.T) {
+	ledger := int64(4294967296) // ledger sequence 1
+	tx := int64(4096)           // tx index 1
+	op := int64(1)              // op index 1
+
+	Convey("TotalOrderId.ToInt64", t, func() {
+		Convey("accomodates 12-bits of precision for the operation", func() {
+			So(TotalOrderId{0, 0, 1}.ToInt64(), ShouldEqual, 1)
+			So(TotalOrderId{0, 0, 4095}.ToInt64(), ShouldEqual, 4095)
+			So(func() { TotalOrderId{0, 0, 4096}.ToInt64() }, ShouldPanic)
+		})
+
+		Convey("accomodates 20-bits of precision for the transaction", func() {
+			So(TotalOrderId{0, 1, 0}.ToInt64(), ShouldEqual, 4096)
+			So(TotalOrderId{0, 1048575, 0}.ToInt64(), ShouldEqual, 4294963200)
+			So(func() { TotalOrderId{0, 1048576, 0}.ToInt64() }, ShouldPanic)
+		})
+
+		Convey("accomodates 32-bits of precision for the ledger", func() {
+			So(TotalOrderId{1, 0, 0}.ToInt64(), ShouldEqual, 4294967296)
+			So(TotalOrderId{math.MaxInt32, 0, 0}.ToInt64(), ShouldEqual, 9223372032559808512)
+			So(func() { TotalOrderId{-1, 0, 0}.ToInt64() }, ShouldPanic)
+			So(func() { TotalOrderId{math.MinInt32, 0, 0}.ToInt64() }, ShouldPanic)
+		})
+
+		Convey("works as expected", func() {
+			So(TotalOrderId{1, 1, 1}.ToInt64(), ShouldEqual, ledger+tx+op)
+			So(TotalOrderId{1, 1, 0}.ToInt64(), ShouldEqual, ledger+tx)
+			So(TotalOrderId{1, 0, 1}.ToInt64(), ShouldEqual, ledger+op)
+			So(TotalOrderId{1, 0, 0}.ToInt64(), ShouldEqual, ledger)
+			So(TotalOrderId{0, 1, 0}.ToInt64(), ShouldEqual, tx)
+			So(TotalOrderId{0, 0, 1}.ToInt64(), ShouldEqual, op)
+			So(TotalOrderId{0, 0, 0}.ToInt64(), ShouldEqual, 0)
+		})
+	})
+
+	Convey("ParseTotalOrderId", t, func() {
+		toid := ParseTotalOrderId(ledger + tx + op)
+		So(toid.LedgerSequence, ShouldEqual, 1)
+		So(toid.TransactionOrder, ShouldEqual, 1)
+		So(toid.OperationOrder, ShouldEqual, 1)
+
+		toid = ParseTotalOrderId(ledger + tx)
+		So(toid.LedgerSequence, ShouldEqual, 1)
+		So(toid.TransactionOrder, ShouldEqual, 1)
+		So(toid.OperationOrder, ShouldEqual, 0)
+
+		toid = ParseTotalOrderId(ledger + op)
+		So(toid.LedgerSequence, ShouldEqual, 1)
+		So(toid.TransactionOrder, ShouldEqual, 0)
+		So(toid.OperationOrder, ShouldEqual, 1)
+
+		toid = ParseTotalOrderId(ledger)
+		So(toid.LedgerSequence, ShouldEqual, 1)
+		So(toid.TransactionOrder, ShouldEqual, 0)
+		So(toid.OperationOrder, ShouldEqual, 0)
+
+		toid = ParseTotalOrderId(tx)
+		So(toid.LedgerSequence, ShouldEqual, 0)
+		So(toid.TransactionOrder, ShouldEqual, 1)
+		So(toid.OperationOrder, ShouldEqual, 0)
+
+		toid = ParseTotalOrderId(op)
+		So(toid.LedgerSequence, ShouldEqual, 0)
+		So(toid.TransactionOrder, ShouldEqual, 0)
+		So(toid.OperationOrder, ShouldEqual, 1)
+	})
+}
+
+func ExampleParseTotalOrderId() {
+	toid := ParseTotalOrderId(12884910080)
+	fmt.Printf("ledger:%d, tx:%d, op:%d", toid.LedgerSequence, toid.TransactionOrder, toid.OperationOrder)
+	// Output: ledger:3, tx:2, op:0
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -13,8 +13,6 @@ func NewTestApp() *App {
 		log.Panic(err)
 	}
 
-	app.historyDb.LogMode(true)
-
 	return app
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,6 +1,9 @@
 package horizon
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"github.com/PuerkitoBio/throttled"
 	"github.com/stellar/go-horizon/test"
 	"log"
@@ -26,4 +29,36 @@ func NewTestConfig() Config {
 
 func NewRequestHelper(app *App) test.RequestHelper {
 	return test.NewRequestHelper(app.web.router)
+}
+
+func ShouldBePageOf(actual interface{}, options ...interface{}) string {
+	body := actual.(*bytes.Buffer)
+	expected := options[0].(int)
+
+	var result map[string]interface{}
+	err := json.Unmarshal(body.Bytes(), &result)
+
+	if err != nil {
+		return fmt.Sprintf("Could not unmarshal json:\n%s\n", body.String())
+	}
+
+	embedded, ok := result["_embedded"]
+
+	if !ok {
+		return "No _embedded key in response"
+	}
+
+	records, ok := embedded.(map[string]interface{})["records"]
+
+	if !ok {
+		return "No records key in _embedded"
+	}
+
+	length := len(records.([]interface{}))
+
+	if length != expected {
+		return fmt.Sprintf("Expected %d records in page, got %d", expected, length)
+	}
+
+	return ""
 }

--- a/init_web.go
+++ b/init_web.go
@@ -62,26 +62,26 @@ func initWebActions(app *App) {
 	app.web.router.Get("/ledgers", ledgerIndexAction)
 	app.web.router.Get("/ledgers/:id", ledgerShowAction)
 	app.web.router.Get("/ledgers/:ledger_id/transactions", transactionIndexAction)
-	app.web.router.Get("/ledgers/:ledger_id/operations", notImplementedAction)
+	app.web.router.Get("/ledgers/:ledger_id/operations", operationIndexAction)
 	app.web.router.Get("/ledgers/:ledger_id/effects", notImplementedAction)
 
 	// account actions
 	app.web.router.Get("/accounts", notImplementedAction)
 	app.web.router.Get("/accounts/:id", accountShowAction)
 	app.web.router.Get("/accounts/:account_id/transactions", transactionIndexAction)
-	app.web.router.Get("/accounts/:account_id/operations", notImplementedAction)
+	app.web.router.Get("/accounts/:account_id/operations", operationIndexAction)
 	app.web.router.Get("/accounts/:account_id/effects", notImplementedAction)
 
 	// transaction actions
 	app.web.router.Get("/transactions", transactionIndexAction)
 	app.web.router.Get("/transactions/:id", transactionShowAction)
-	app.web.router.Get("/transactions/:tx_id/operations", notImplementedAction)
+	app.web.router.Get("/transactions/:tx_id/operations", operationIndexAction)
 	app.web.router.Get("/transactions/:tx_id/effects", notImplementedAction)
 
 	// transaction actions
-	app.web.router.Get("/operations", notImplementedAction)
+	app.web.router.Get("/operations", operationIndexAction)
 	app.web.router.Get("/operations/:id", notImplementedAction)
-	app.web.router.Get("/operations/:tx_id/effects", notImplementedAction)
+	app.web.router.Get("/operations/:op_id/effects", notImplementedAction)
 
 	app.web.router.NotFound(notFoundAction)
 }


### PR DESCRIPTION
In addition to the addition of the `operations` endpoints, this PR:
- Removes gorm and updates the query system to use `SqlQuery`.  Much simpler data access
- Adds `TotalOrderId`
- Improves documentation
- Improves test suite helpers and some individual tests

Fixes #12 
