### PR TITLE
Request context

### DIFF
--- a/action_helper.go
+++ b/action_helper.go
@@ -1,8 +1,10 @@
 package horizon
 
 import (
+	gctx "github.com/goji/context"
 	"github.com/stellar/go-horizon/db"
 	"github.com/zenazn/goji/web"
+	"golang.org/x/net/context"
 	"net/http"
 	"strconv"
 )
@@ -36,6 +38,10 @@ func (a *ActionHelper) Err() error {
 
 func (a *ActionHelper) App() *App {
 	return a.c.Env["app"].(*App)
+}
+
+func (a *ActionHelper) Context() context.Context {
+	return gctx.FromC(a.c)
 }
 
 // Gets a string from either the URLParams or query string.

--- a/actions_account.go
+++ b/actions_account.go
@@ -40,7 +40,7 @@ func accountShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	app := ah.App()
 	address := ah.GetString("id")
 	if ah.Err() != nil {
-		problem.Render(app.ctx, w, problem.NotFound)
+		problem.Render(ah.Context(), w, problem.NotFound)
 		return
 	}
 
@@ -49,7 +49,7 @@ func accountShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 		address,
 	}
 
-	render.Single(w, r, q, func(r db.Record) (render.Resource, error) {
+	render.Single(ah.Context(), w, r, q, func(r db.Record) (render.Resource, error) {
 		return NewAccountResource(r.(db.CoreAccountRecord)), nil
 	})
 }

--- a/actions_account_test.go
+++ b/actions_account_test.go
@@ -12,7 +12,7 @@ func TestAccountActions(t *testing.T) {
 	Convey("Account Actions:", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
-		defer app.Cancel()
+		defer app.Close()
 		rh := NewRequestHelper(app)
 
 		Convey("GET /accounts/gspbxqXqEUZkiCCEFFCN9Vu4FLucdjLLdLcsV6E82Qc1T7ehsTC", func() {

--- a/actions_ledger.go
+++ b/actions_ledger.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stellar/go-horizon/render"
 	"github.com/stellar/go-horizon/render/problem"
 	"github.com/zenazn/goji/web"
-	"golang.org/x/net/context"
 	"net/http"
 	"time"
 )
@@ -61,7 +60,7 @@ func ledgerIndexAction(c web.C, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.Collection(w, r, query, ledgerRecordToResource)
+	render.Collection(ah.Context(), w, r, query, ledgerRecordToResource)
 }
 
 func ledgerShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
@@ -70,13 +69,13 @@ func ledgerShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	sequence := ah.GetInt32("id")
 
 	if ah.Err() != nil {
-		problem.Render(context.TODO(), w, problem.NotFound)
+		problem.Render(ah.Context(), w, problem.NotFound)
 		return
 	}
 
 	query := db.LedgerBySequenceQuery{app.HistoryQuery(), sequence}
 
-	render.Single(w, r, query, ledgerRecordToResource)
+	render.Single(ah.Context(), w, r, query, ledgerRecordToResource)
 }
 
 func ledgerRecordToResource(record db.Record) (render.Resource, error) {

--- a/actions_ledger_test.go
+++ b/actions_ledger_test.go
@@ -12,7 +12,7 @@ func TestLedgerActions(t *testing.T) {
 	Convey("Ledger Actions:", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
-		defer app.Cancel()
+		defer app.Close()
 		rh := NewRequestHelper(app)
 
 		Convey("GET /ledgers/1", func() {

--- a/actions_not_found.go
+++ b/actions_not_found.go
@@ -3,10 +3,10 @@ package horizon
 import (
 	"github.com/stellar/go-horizon/render/problem"
 	"github.com/zenazn/goji/web"
-	"golang.org/x/net/context"
 	"net/http"
 )
 
 func notFoundAction(c web.C, w http.ResponseWriter, r *http.Request) {
-	problem.Render(context.TODO(), w, problem.NotFound)
+	ah := &ActionHelper{c: c, r: r}
+	problem.Render(ah.Context(), w, problem.NotFound)
 }

--- a/actions_not_implemented.go
+++ b/actions_not_implemented.go
@@ -3,10 +3,10 @@ package horizon
 import (
 	"github.com/stellar/go-horizon/render/problem"
 	"github.com/zenazn/goji/web"
-	"golang.org/x/net/context"
 	"net/http"
 )
 
 func notImplementedAction(c web.C, w http.ResponseWriter, r *http.Request) {
-	problem.Render(context.TODO(), w, problem.NotImplemented)
+	ah := &ActionHelper{c: c, r: r}
+	problem.Render(ah.Context(), w, problem.NotImplemented)
 }

--- a/actions_operation.go
+++ b/actions_operation.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stellar/go-horizon/render"
 	"github.com/stellar/go-horizon/render/problem"
 	"github.com/zenazn/goji/web"
-	"golang.org/x/net/context"
 	"net/http"
 )
 
@@ -34,11 +33,11 @@ func operationIndexAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ah.Err() != nil {
-		problem.Render(context.TODO(), w, problem.ServerError)
+		problem.Render(ah.Context(), w, problem.ServerError)
 		return
 	}
 
-	render.Collection(w, r, q, operationRecordToResource)
+	render.Collection(ah.Context(), w, r, q, operationRecordToResource)
 }
 
 func operationRecordToResource(record db.Record) (render.Resource, error) {

--- a/actions_operation_test.go
+++ b/actions_operation_test.go
@@ -9,7 +9,7 @@ import (
 func TestOperationActions(t *testing.T) {
 	test.LoadScenario("base")
 	app := NewTestApp()
-	defer app.Cancel()
+	defer app.Close()
 	rh := NewRequestHelper(app)
 
 	Convey("Operation Actions:", t, func() {

--- a/actions_root_test.go
+++ b/actions_root_test.go
@@ -11,7 +11,7 @@ func TestRootAction(t *testing.T) {
 	Convey("GET /", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
-		defer app.Cancel()
+		defer app.Close()
 		rh := NewRequestHelper(app)
 
 		w := rh.Get("/", test.RequestHelperNoop)

--- a/actions_transaction.go
+++ b/actions_transaction.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stellar/go-horizon/render"
 	"github.com/stellar/go-horizon/render/problem"
 	"github.com/zenazn/goji/web"
-	"golang.org/x/net/context"
 	"net/http"
 )
 
@@ -49,11 +48,11 @@ func transactionIndexAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ah.Err() != nil {
-		problem.Render(context.TODO(), w, problem.ServerError)
+		problem.Render(ah.Context(), w, problem.ServerError)
 		return
 	}
 
-	render.Collection(w, r, q, transactionRecordToResource)
+	render.Collection(ah.Context(), w, r, q, transactionRecordToResource)
 }
 
 func transactionShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
@@ -62,7 +61,7 @@ func transactionShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 	hash := ah.GetString("id")
 
 	if ah.Err() != nil {
-		problem.Render(context.TODO(), w, problem.NotFound)
+		problem.Render(ah.Context(), w, problem.NotFound)
 		return
 	}
 
@@ -71,7 +70,7 @@ func transactionShowAction(c web.C, w http.ResponseWriter, r *http.Request) {
 		hash,
 	}
 
-	render.Single(w, r, q, transactionRecordToResource)
+	render.Single(ah.Context(), w, r, q, transactionRecordToResource)
 }
 
 func transactionRecordToResource(record db.Record) (render.Resource, error) {

--- a/actions_transaction_test.go
+++ b/actions_transaction_test.go
@@ -12,7 +12,7 @@ func TestTransactionActions(t *testing.T) {
 	Convey("Transactions Actions:", t, func() {
 		test.LoadScenario("base")
 		app := NewTestApp()
-		defer app.Cancel()
+		defer app.Close()
 		rh := NewRequestHelper(app)
 
 		Convey("GET /transactions/da3dae3d6baef2f56d53ff9fa4ddbc6cbda1ac798f0faa7de8edac9597c1dc0c", func() {

--- a/app.go
+++ b/app.go
@@ -121,9 +121,11 @@ func (a *App) Serve() {
 
 	graceful.HandleSignals()
 	bind.Ready()
-	graceful.PreHook(func() { log.Printf("received signal, gracefully stopping") })
-	graceful.PostHook(func() {
+	graceful.PreHook(func() {
+		log.Printf("received signal, gracefully stopping")
 		a.Cancel()
+	})
+	graceful.PostHook(func() {
 		log.Printf("stopped")
 	})
 
@@ -144,9 +146,13 @@ func (a *App) Serve() {
 }
 
 func (a *App) Cancel() {
+	a.cancel()
+}
+
+func (a *App) Close() {
+	a.Cancel()
 	a.historyDb.Close()
 	a.coreDb.Close()
-	a.cancel()
 }
 
 // Returns a SqlQuery that can be embedded in a parent query

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,18 @@
+package horizon
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestApp(t *testing.T) {
+	Convey("NewApp establishes the app in its context", t, func() {
+		app, err := NewApp(NewTestConfig())
+		So(err, ShouldBeNil)
+		defer app.Close()
+
+		found, ok := AppFromContext(app.ctx)
+		So(ok, ShouldBeTrue)
+		So(found, ShouldEqual, app)
+	})
+}

--- a/context/requestid/main.go
+++ b/context/requestid/main.go
@@ -1,0 +1,36 @@
+// This package provides functions to support embedded and retrieving
+// a request id from a go context tree
+package requestid
+
+import (
+	"github.com/zenazn/goji/web"
+	"github.com/zenazn/goji/web/middleware"
+	"golang.org/x/net/context"
+)
+
+var key struct{}
+
+// Establishes a context from the provided parent and the provided request id
+// string.
+//
+// Returns the derived context
+func Context(ctx context.Context, reqid string) context.Context {
+	return context.WithValue(ctx, &key, reqid)
+}
+
+func ContextFromC(ctx context.Context, c *web.C) context.Context {
+	reqid := middleware.GetReqID(*c)
+	return Context(ctx, reqid)
+}
+
+// Returns the set request id, if one has been set, from the provided context
+// returns "" if no requestid has been set
+func FromContext(ctx context.Context) string {
+	result, ok := ctx.Value(&key).(string)
+
+	if ok {
+		return result
+	} else {
+		return ""
+	}
+}

--- a/context/requestid/main_test.go
+++ b/context/requestid/main_test.go
@@ -1,0 +1,40 @@
+package requestid
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/zenazn/goji/web"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+func TestRequestId(t *testing.T) {
+	Convey("requestid.Context", t, func() {
+		ctx := Context(context.Background(), "2")
+		So(ctx.Value(&key), ShouldEqual, "2")
+
+		ctx2 := Context(ctx, "3")
+
+		So(ctx.Value(&key), ShouldEqual, "2")
+		So(ctx2.Value(&key), ShouldEqual, "3")
+	})
+
+	Convey("requestid.ContextFromC", t, func() {
+		gojiC := web.C{
+			Env: make(map[interface{}]interface{}),
+		}
+
+		gojiC.Env["reqID"] = "foobar"
+
+		ctx := ContextFromC(context.Background(), &gojiC)
+		So(FromContext(ctx), ShouldEqual, "foobar")
+	})
+
+	Convey("requestid.FromContext", t, func() {
+		ctx := Context(context.Background(), "2")
+		ctx2 := Context(ctx, "3")
+
+		So(FromContext(context.Background()), ShouldEqual, "")
+		So(FromContext(ctx), ShouldEqual, "2")
+		So(FromContext(ctx2), ShouldEqual, "3")
+	})
+}

--- a/init_redis_test.go
+++ b/init_redis_test.go
@@ -12,7 +12,7 @@ func TestRedis(t *testing.T) {
 		c := NewTestConfig()
 		c.RedisUrl = "redis://127.0.0.1:6379/"
 		app, _ := NewApp(c)
-		defer app.Cancel()
+		defer app.Close()
 		So(app.redis, ShouldNotBeNil)
 	})
 
@@ -20,7 +20,7 @@ func TestRedis(t *testing.T) {
 		c := NewTestConfig()
 		c.RedisUrl = ""
 		app, _ := NewApp(c)
-		defer app.Cancel()
+		defer app.Close()
 		So(app.redis, ShouldBeNil)
 	})
 
@@ -28,7 +28,7 @@ func TestRedis(t *testing.T) {
 		conf := NewTestConfig()
 		conf.RedisUrl = "redis://127.0.0.1:6379/"
 		app, _ := NewApp(conf)
-		defer app.Cancel()
+		defer app.Close()
 
 		c := app.redis.Get()
 		defer c.Close()

--- a/init_web.go
+++ b/init_web.go
@@ -41,14 +41,14 @@ func initWebMetrics(app *App) {
 func initWebMiddleware(app *App) {
 	r := app.web.router
 	r.Use(middleware.EnvInit)
+	r.Use(app.Middleware)
+	r.Use(middleware.RequestID)
 	r.Use(contextMiddleware(app.ctx))
 	r.Use(xff.XFF)
-	r.Use(middleware.RequestID)
-	r.Use(app.Middleware)
 	r.Use(middleware.Logger)
+	r.Use(requestMetricsMiddleware)
 	r.Use(RecoverMiddleware)
 	r.Use(middleware.AutomaticOptions)
-	r.Use(requestMetricsMiddleware)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/middleware_context.go
+++ b/middleware_context.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	gctx "github.com/goji/context"
+	"github.com/stellar/go-horizon/context/requestid"
 	"github.com/stellar/go-horizon/httpx"
 	"github.com/zenazn/goji/web"
 	"golang.org/x/net/context"
@@ -11,13 +12,15 @@ import (
 func contextMiddleware(parent context.Context) func(c *web.C, next http.Handler) http.Handler {
 	return func(c *web.C, next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
+			ctx := parent
+			ctx = requestid.ContextFromC(ctx, c)
 
+			// establish "cancel on close" context if possible
 			if _, ok := w.(http.CloseNotifier); ok {
-				gctx.Set(c, httpx.CancelWhenClosed(parent, w))
-			} else {
-				gctx.Set(c, parent)
+				ctx = httpx.CancelWhenClosed(ctx, w)
 			}
 
+			gctx.Set(c, ctx)
 			next.ServeHTTP(w, r)
 		}
 		return http.HandlerFunc(fn)

--- a/middleware_context.go
+++ b/middleware_context.go
@@ -1,0 +1,25 @@
+package horizon
+
+import (
+	gctx "github.com/goji/context"
+	"github.com/stellar/go-horizon/httpx"
+	"github.com/zenazn/goji/web"
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+func contextMiddleware(parent context.Context) func(c *web.C, next http.Handler) http.Handler {
+	return func(c *web.C, next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+
+			if _, ok := w.(http.CloseNotifier); ok {
+				gctx.Set(c, httpx.CancelWhenClosed(parent, w))
+			} else {
+				gctx.Set(c, parent)
+			}
+
+			next.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/middleware_rate_limit_test.go
+++ b/middleware_rate_limit_test.go
@@ -11,7 +11,7 @@ func TestRateLimitMiddleware(t *testing.T) {
 
 	Convey("Rate Limiting", t, func() {
 		app := NewTestApp()
-		defer app.Cancel()
+		defer app.Close()
 		rh := NewRequestHelper(app)
 
 		Convey("sets X-RateLimit-Limit headers correctly", func() {
@@ -84,7 +84,7 @@ func TestRateLimitMiddleware(t *testing.T) {
 		c := NewTestConfig()
 		c.RedisUrl = "redis://127.0.0.1:6379/"
 		app, _ := NewApp(c)
-		defer app.Cancel()
+		defer app.Close()
 		rh := NewRequestHelper(app)
 
 		redis := app.redis.Get()

--- a/middleware_recover.go
+++ b/middleware_recover.go
@@ -3,10 +3,10 @@ package horizon
 import (
 	"bytes"
 	"fmt"
+	gctx "github.com/goji/context"
 	"github.com/stellar/go-horizon/render/problem"
 	"github.com/zenazn/goji/web"
 	. "github.com/zenazn/goji/web/middleware"
-	"golang.org/x/net/context"
 	"log"
 	"net/http"
 	"runtime/debug"
@@ -21,7 +21,7 @@ func RecoverMiddleware(c *web.C, h http.Handler) http.Handler {
 				printPanic(reqID, err)
 				debug.PrintStack()
 				//TODO: include stack trace if in debug mode
-				problem.Render(context.TODO(), w, problem.ServerError)
+				problem.Render(gctx.FromC(*c), w, problem.ServerError)
 			}
 		}()
 

--- a/render/problem/main.go
+++ b/render/problem/main.go
@@ -2,6 +2,7 @@ package problem
 
 import (
 	"encoding/json"
+	"github.com/stellar/go-horizon/context/requestid"
 	"golang.org/x/net/context"
 	"net/http"
 )
@@ -29,10 +30,17 @@ func FromError(ctx context.Context, err error) P {
 	return result
 }
 
-func Render(ctx context.Context, w http.ResponseWriter, p P) {
-
+func Inflate(ctx context.Context, p *P) {
 	//TODO: inflate type into full url
 	//TODO: add requesting url to extra info
+
+	p.Instance = requestid.FromContext(ctx)
+
+}
+
+func Render(ctx context.Context, w http.ResponseWriter, p P) {
+
+	Inflate(ctx, &p)
 
 	w.Header().Set("Content-Type", "application/problem+json")
 	js, err := json.MarshalIndent(p, "", "  ")

--- a/render/problem/main_test.go
+++ b/render/problem/main_test.go
@@ -2,36 +2,52 @@ package problem
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/go-horizon/context/requestid"
 	"golang.org/x/net/context"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestMain(t *testing.T) {
+	b := context.Background()
 
 	Convey("Common Problems", t, func() {
-		render := func(p P) *httptest.ResponseRecorder {
+		render := func(ctx context.Context, p P) *httptest.ResponseRecorder {
 			w := httptest.NewRecorder()
-			Render(context.Background(), w, p)
+			Render(ctx, w, p)
 			return w
 		}
 
 		Convey("NotFound", func() {
-			w := render(NotFound)
+			w := render(b, NotFound)
 			So(w.Code, ShouldEqual, 404)
 			t.Log(w.Body.String())
 		})
 
 		Convey("ServerError", func() {
-			w := render(ServerError)
+			w := render(b, ServerError)
 			So(w.Code, ShouldEqual, 500)
 			t.Log(w.Body.String())
 		})
 
 		Convey("RateLimitExceeded", func() {
-			w := render(RateLimitExceeded)
+			w := render(b, RateLimitExceeded)
 			So(w.Code, ShouldEqual, 429)
 			t.Log(w.Body.String())
+		})
+	})
+
+	Convey("problem.Inflate", t, func() {
+		Convey("sets Instance to the request id based upon the context", func() {
+			ctx := requestid.Context(b, "2")
+			p := P{}
+			Inflate(ctx, &p)
+
+			So(p.Instance, ShouldEqual, "2")
+
+			// when no request id is set, instance should be ""
+			Inflate(b, &p)
+			So(p.Instance, ShouldEqual, "")
 		})
 	})
 

--- a/render/sse/main.go
+++ b/render/sse/main.go
@@ -3,7 +3,6 @@ package sse
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stellar/go-horizon/httpx"
 	"golang.org/x/net/context"
 	"log"
 	"net/http"
@@ -52,9 +51,6 @@ func (s *Streamer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Setup cancelation signal that gets triggered if the client disconnects
-	ctx := httpx.CancelWhenClosed(s.Ctx, w)
-
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -73,7 +69,7 @@ func (s *Streamer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			writeEvent(w, event)
-		case <-ctx.Done():
+		case <-s.Ctx.Done():
 			return
 		}
 	}


### PR DESCRIPTION
This PR links our http processing pipeline with go's context system.  Specifically, it:
- Links an App into the context tree, allowing children to retrieve a `*App` using `AppFromContext(ctx)`
- Injects the current request's ID into the context tree
- Hooks the request id up to the problem renderer, populating the problem's `Instance` property correctly
- Reorders middleware to provide contextual information earlier in the stack
- Adds `ActionHelper.Context()` helper

This PR also fixes a shutdown bug, which prevented clean shutdown whenever an open streaming query connection was present.
