### PR TITLE
SSE System Refactoring

### DIFF
--- a/actions_account.go
+++ b/actions_account.go
@@ -27,7 +27,7 @@ func accountIndexAction(c web.C, w http.ResponseWriter, r *http.Request) {
 		ha := record.(db.HistoryAccountRecord)
 
 		return HistoryAccountResource{
-			Id:          ha.Address,
+			ID:          ha.Address,
 			PagingToken: ha.PagingToken(),
 			Address:     ha.Address,
 		}, nil

--- a/actions_ledger_test.go
+++ b/actions_ledger_test.go
@@ -2,9 +2,10 @@ package horizon
 
 import (
 	"encoding/json"
+	"testing"
+
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stellar/go-horizon/test"
-	"testing"
 )
 
 func TestLedgerActions(t *testing.T) {

--- a/render/main.go
+++ b/render/main.go
@@ -13,29 +13,40 @@ import (
 )
 
 const (
+	//MimeEventStream is the mime type for "text/event-stream"
 	MimeEventStream = "text/event-stream"
-	MimeHal         = "application/hal+json"
-	MimeJson        = "application/json"
-	MimeProblem     = "application/problem+json"
+	//MimeHal is the mime type for "application/hal+json"
+	MimeHal = "application/hal+json"
+	//MimeJSON is the mime type for "application/json"
+	MimeJSON = "application/json"
+	//MimeProblem is the mime type for application/problem+json"
+	MimeProblem = "application/problem+json"
 )
 
 var (
-	InvalidStreamEvent error
+	// ErrInvalidStreamEvent is emitted when the returned value of a given
+	// transform function returns a resource that cannot be converted into an
+	// sse.Event.
+	ErrInvalidStreamEvent = errors.New("provided `Transform` did not return an implementer of `sse.Eventable`")
 )
 
-func init() {
-	InvalidStreamEvent = errors.New("provided `Transform` did not return an implementer of `sse.Event`")
-}
-
+// Resource gets rendered to HAL-compatible json.
 type Resource interface{}
-type Transform func(db.Record) (Resource, error)
-type ToEvent func(interface{}) sse.Event
 
+// Transform takes a database record and should return a Resource that will
+// get transformed into JSON and rendered to the requesting client.
+type Transform func(db.Record) (Resource, error)
+
+// Collection renders multiple records, retrieved using q, as a HAL-formatted page.
+//
+// In the event that `r` is requesting a streamed response, we register a
+// listener with the database streaming system and forward rendering on to the
+// SSE system.
 func Collection(ctx context.Context, w http.ResponseWriter, r *http.Request, q db.Query, t Transform) {
 	contentType := Negotiate(r)
 
 	switch contentType {
-	case MimeHal, MimeJson:
+	case MimeHal, MimeJSON:
 		records, err := db.Results(ctx, q)
 		if err != nil {
 			panic(err)
@@ -63,29 +74,19 @@ func Collection(ctx context.Context, w http.ResponseWriter, r *http.Request, q d
 	case MimeEventStream:
 
 		records := db.Stream(ctx, q)
-		events := recordToEvent(records.Get(), func(r interface{}) sse.Event {
-			resource, err := t(r)
-
-			if err != nil {
-				return sse.ErrorEvent{err}
-			}
-
-			event, ok := resource.(sse.Event)
-
-			if !ok {
-				return sse.ErrorEvent{InvalidStreamEvent}
-			}
-
-			return event
-		})
-
-		streamer := &sse.Streamer{ctx, events}
+		events := recordToEvent(records.Get(), t)
+		streamer := &sse.Streamer{
+			Ctx:  ctx,
+			Data: events,
+		}
 		streamer.ServeHTTP(w, r)
 	default:
+		//TODO: render a NotAcceptableProblem
 		http.Error(w, "bad accept", http.StatusNotAcceptable)
 	}
 }
 
+// Single triggers the rendering of a singular resource.
 func Single(ctx context.Context, w http.ResponseWriter, r *http.Request, q db.Query, t Transform) {
 	record, err := db.First(ctx, q)
 
@@ -107,8 +108,10 @@ func Single(ctx context.Context, w http.ResponseWriter, r *http.Request, q db.Qu
 	}
 }
 
+// Negotiate inspects the Accept header of the provided request and determines
+// what the most appropriate response type should be.  Defaults to HAL.
 func Negotiate(r *http.Request) string {
-	alternatives := []string{MimeHal, MimeJson, MimeEventStream}
+	alternatives := []string{MimeHal, MimeJSON, MimeEventStream}
 	accept := r.Header.Get("Accept")
 
 	if accept == "" {
@@ -118,19 +121,32 @@ func Negotiate(r *http.Request) string {
 	return goautoneg.Negotiate(r.Header.Get("Accept"), alternatives)
 }
 
-func recordToEvent(in <-chan db.StreamRecord, t ToEvent) <-chan sse.Event {
-	chn := make(chan sse.Event)
+func recordToEvent(in <-chan db.StreamRecord, t Transform) <-chan sse.Eventable {
+	chn := make(chan sse.Eventable)
 
 	go func() {
 		for sr := range in {
 			err := sr.Err
 
 			if err != nil {
-				chn <- sse.ErrorEvent{err}
-			} else {
-				chn <- t(sr.Record)
+				chn <- sse.Event{Error: err}
+				continue
 			}
 
+			resource, err := t(sr.Record)
+			if err != nil {
+				chn <- sse.Event{Error: err}
+				continue
+			}
+
+			eventable, ok := resource.(sse.Eventable)
+
+			if !ok {
+				chn <- sse.Event{Error: ErrInvalidStreamEvent}
+				continue
+			}
+
+			chn <- eventable
 		}
 		close(chn)
 	}()

--- a/render/sse/main.go
+++ b/render/sse/main.go
@@ -76,26 +76,26 @@ func (s *Streamer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// wait for data and stream it as it becomes available
 	// finish when either the client closes the connection
 	// or the data provider closes the channel
-	writeEvent(w, helloEvent)
+	WriteEvent(w, helloEvent)
 	for {
 		select {
 		case eventable, more := <-s.Data:
 			if !more {
-				writeEvent(w, goodbyeEvent)
+				WriteEvent(w, goodbyeEvent)
 				return
 			}
-			writeEvent(w, eventable.SseEvent())
+			WriteEvent(w, eventable.SseEvent())
 		case <-s.Ctx.Done():
 			return
 		}
 	}
 }
 
-// writeEvent does the actual work of formatting an SSE compliant message
+// WriteEvent does the actual work of formatting an SSE compliant message
 // sending it over the provided ResponseWriter and flushing.
-func writeEvent(w http.ResponseWriter, e Event) {
+func WriteEvent(w http.ResponseWriter, e Event) {
 	if e.Error != nil {
-		fmt.Fprint(w, "event: error\n")
+		fmt.Fprint(w, "event: err\n")
 		fmt.Fprintf(w, "data: %s\n\n", e.Error.Error())
 		w.(http.Flusher).Flush()
 		return

--- a/render/sse/main_test.go
+++ b/render/sse/main_test.go
@@ -1,0 +1,30 @@
+package sse
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSsePackage(t *testing.T) {
+	Convey("sse.WriteEvent outputs data properly", t, func() {
+		expectations := []struct {
+			Event     Event
+			Substring string
+		}{
+			{Event{Data: "test"}, "data: \"test\"\n\n"},
+			{Event{ID: "1", Data: "test"}, "id: 1\n"},
+			{Event{Retry: 1000, Data: "test"}, "retry: 1000\n"},
+			{Event{Error: errors.New("busted")}, "event: err\ndata: busted\n\n"},
+			{Event{Event: "test", Data: "test"}, "event: test\ndata: \"test\"\n\n"},
+		}
+
+		for _, e := range expectations {
+			w := httptest.NewRecorder()
+			WriteEvent(w, e.Event)
+			So(w.Body.String(), ShouldContainSubstring, e.Substring)
+		}
+	})
+}

--- a/render/sse/main_test.go
+++ b/render/sse/main_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/go-horizon/test"
 )
 
 func TestSsePackage(t *testing.T) {
+	ctx, log := test.ContextWithLogBuffer()
+
 	Convey("sse.WriteEvent outputs data properly", t, func() {
 		expectations := []struct {
 			Event     Event
@@ -23,8 +26,15 @@ func TestSsePackage(t *testing.T) {
 
 		for _, e := range expectations {
 			w := httptest.NewRecorder()
-			WriteEvent(w, e.Event)
+			WriteEvent(ctx, w, e.Event)
 			So(w.Body.String(), ShouldContainSubstring, e.Substring)
 		}
+	})
+
+	Convey("sse.WriteEvent logs errors", t, func() {
+		w := httptest.NewRecorder()
+		WriteEvent(ctx, w, Event{Error: errors.New("busted")})
+		So(log.String(), ShouldContainSubstring, "level=error")
+		So(log.String(), ShouldContainSubstring, "busted")
 	})
 }

--- a/resource_account.go
+++ b/resource_account.go
@@ -10,7 +10,7 @@ import (
 // AccountResource is the summary of an account
 type AccountResource struct {
 	halgo.Links
-	Id          string            `json:"id"`
+	ID          string            `json:"id"`
 	PagingToken string            `json:"paging_token"`
 	Address     string            `json:"address"`
 	Sequence    int64             `json:"sequence"`
@@ -59,7 +59,7 @@ func NewAccountResource(ac db.AccountRecord) AccountResource {
 			Link("operations", "%s/operations/%s", self, po).
 			Link("effects", "%s/effects/%s", self, po).
 			Link("offers", "%s/offers/%s", self, po),
-		Id:          address,
+		ID:          address,
 		PagingToken: ac.PagingToken(),
 		Address:     address,
 		Sequence:    ac.Seqnum,

--- a/resource_history_account.go
+++ b/resource_history_account.go
@@ -1,13 +1,20 @@
 package horizon
 
+import "github.com/stellar/go-horizon/render/sse"
+
 // HistoryAccountResource is a simple resource, used for the account collection actions.
 // It provides only the TotalOrderId of the account and its address.
 type HistoryAccountResource struct {
-	Id          string `json:"id"`
+	ID          string `json:"id"`
 	PagingToken string `json:"paging_token"`
 	Address     string `json:"address"`
 }
 
-func (r HistoryAccountResource) SseData() interface{} { return r }
-func (r HistoryAccountResource) Err() error           { return nil }
-func (r HistoryAccountResource) SseId() string        { return r.PagingToken }
+// SseEvent converts this resource into a SSE compatible event.  Implements
+// the sse.Eventable interface
+func (r HistoryAccountResource) SseEvent() sse.Event {
+	return sse.Event{
+		Data: r,
+		ID:   r.PagingToken,
+	}
+}

--- a/resource_ledger.go
+++ b/resource_ledger.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/jagregory/halgo"
 	"github.com/stellar/go-horizon/db"
+	"github.com/stellar/go-horizon/render/sse"
 )
 
 // LedgerResource represents the summary of a single ledger
 type LedgerResource struct {
 	halgo.Links
-	Id               string         `json:"id"`
+	ID               string         `json:"id"`
 	PagingToken      string         `json:"paging_token"`
 	Hash             string         `json:"hash"`
 	PrevHash         sql.NullString `json:"prev_hash"`
@@ -22,9 +23,14 @@ type LedgerResource struct {
 	ClosedAt         time.Time      `json:"closed_at"`
 }
 
-func (l LedgerResource) SseData() interface{} { return l }
-func (l LedgerResource) Err() error           { return nil }
-func (l LedgerResource) SseId() string        { return l.PagingToken }
+// SseEvent converts this resource into a SSE compatible event.  Implements
+// the sse.Eventable interface
+func (l LedgerResource) SseEvent() sse.Event {
+	return sse.Event{
+		Data: l,
+		ID:   l.PagingToken,
+	}
+}
 
 // NewLedgerResource creates a new resource from a db.LedgerRecord
 func NewLedgerResource(in db.LedgerRecord) LedgerResource {
@@ -35,7 +41,7 @@ func NewLedgerResource(in db.LedgerRecord) LedgerResource {
 			Link("transactions", self+"/transactions{?cursor}{?limit}{?order}").
 			Link("operations", self+"/operations{?cursor}{?limit}{?order}").
 			Link("effects", self+"/effects{?cursor}{?limit}{?order}"),
-		Id:          in.LedgerHash,
+		ID:          in.LedgerHash,
 		PagingToken: in.PagingToken(),
 		Hash:        in.LedgerHash,
 		PrevHash:    in.PreviousLedgerHash,

--- a/resource_offer.go
+++ b/resource_offer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stellar/go-horizon/db"
 	"github.com/stellar/go-horizon/render"
+	"github.com/stellar/go-horizon/render/sse"
 )
 
 // OfferResource is the display form of an offer to trade currency.
@@ -37,9 +38,14 @@ type PriceResource struct {
 	D int32 `json:"denominator"`
 }
 
-func (r OfferResource) SseData() interface{} { return r }
-func (r OfferResource) Err() error           { return nil }
-func (r OfferResource) SseId() string        { return r.PagingToken }
+// SseEvent converts this resource into a SSE compatible event.  Implements
+// the sse.Eventable interface
+func (r OfferResource) SseEvent() sse.Event {
+	return sse.Event{
+		Data: r,
+		ID:   r.PagingToken,
+	}
+}
 
 func offerRecordToResource(record db.Record) (result render.Resource, err error) {
 

--- a/resource_operation.go
+++ b/resource_operation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go-horizon/db"
 	"github.com/stellar/go-horizon/render"
+	"github.com/stellar/go-horizon/render/sse"
 )
 
 // PaymentResource contains the payment specific details for a payment operation
@@ -15,6 +16,15 @@ type PaymentResource struct {
 	From   string `json:"from"`
 	To     string `json:"to"`
 	Amount string `json:"amount"`
+}
+
+// SseEvent converts this resource into a SSE compatible event.  Implements
+// the sse.Eventable interface
+func (r PaymentResource) SseEvent() sse.Event {
+	return sse.Event{
+		Data: r,
+		ID:   r.PagingToken,
+	}
 }
 
 // OperationResource is the display form of an operation.
@@ -26,9 +36,14 @@ type OperationResource struct {
 	TypeString  string `json:"type_s"`
 }
 
-func (r OperationResource) SseData() interface{} { return r }
-func (r OperationResource) Err() error           { return nil }
-func (r OperationResource) SseId() string        { return r.PagingToken }
+// SseEvent converts this resource into a SSE compatible event.  Implements
+// the sse.Eventable interface
+func (r OperationResource) SseEvent() sse.Event {
+	return sse.Event{
+		Data: r,
+		ID:   r.PagingToken,
+	}
+}
 
 func operationRecordToResource(record db.Record) (result render.Resource, err error) {
 

--- a/resource_transaction.go
+++ b/resource_transaction.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stellar/go-horizon/db"
 	"github.com/stellar/go-horizon/render"
+	"github.com/stellar/go-horizon/render/sse"
 )
 
 // TransactionResource is the display form of a transaction.
@@ -28,9 +29,14 @@ type TransactionResource struct {
 	ResultMetaXdr    string `json:"result_meta_xdr"`
 }
 
-func (r TransactionResource) SseData() interface{} { return r }
-func (r TransactionResource) Err() error           { return nil }
-func (r TransactionResource) SseId() string        { return r.PagingToken }
+// SseEvent converts this resource into a SSE compatible event.  Implements
+// the sse.Eventable interface
+func (r TransactionResource) SseEvent() sse.Event {
+	return sse.Event{
+		Data: r,
+		ID:   r.PagingToken,
+	}
+}
 
 func transactionRecordToResource(record db.Record) (render.Resource, error) {
 	tx := record.(db.TransactionRecord)

--- a/test/main.go
+++ b/test/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/Sirupsen/logrus"
 	glog "github.com/stellar/go-horizon/log"
 	"golang.org/x/net/context"
 )
@@ -94,4 +95,18 @@ func loadSqlFile(url string, path string) {
 // context).  This context has a logger bound to it suitable for testing.
 func Context() context.Context {
 	return glog.Context(context.Background(), testLogger)
+}
+
+// ContextWithLogBuffer returns a context and a buffer into which the new, bound
+// logger will write into.  This method allows you to inspect what data was
+// logged more easily in your tests.
+func ContextWithLogBuffer() (context.Context, *bytes.Buffer) {
+	output := new(bytes.Buffer)
+	l, _ := glog.New()
+	l.Logger.Out = output
+	l.Logger.Level = logrus.DebugLevel
+
+	ctx := glog.Context(context.Background(), l)
+	return ctx, output
+
 }


### PR DESCRIPTION
In addition to much delinting, the primary change in this PR is to move `sse.Event` from an interface to a struct and introduces the `sse.Eventable` interface.  This simplifies what a resource must implement to be compliant with the streaming system, down to a single method `SseEvent()`
