### PR TITLE
Refactor initialization system:

### DIFF
--- a/app.go
+++ b/app.go
@@ -30,15 +30,6 @@ type App struct {
 	logMetrics *log.Metrics
 }
 
-func initAppContext(app *App) {
-	ctx, cancel := context.WithCancel(context.Background())
-	ctx = context.WithValue(ctx, &appContextKey, app)
-
-	ctx = log.Context(ctx, app.log)
-	app.ctx = ctx
-	app.cancel = cancel
-}
-
 // AppFromContext retrieves a *App from the context tree.
 func AppFromContext(ctx context.Context) (*App, bool) {
 	a, ok := ctx.Value(&appContextKey).(*App)
@@ -48,113 +39,8 @@ func AppFromContext(ctx context.Context) (*App, bool) {
 // NewApp constructs an new App instance from the provided config.
 func NewApp(config Config) (*App, error) {
 
-	init := &AppInit{}
-	init.Add(Initializer{
-		"app-context",
-		initAppContext,
-		[]string{
-			"log",
-		},
-	})
-	init.Add(Initializer{
-		"metrics",
-		initMetrics,
-		nil,
-	})
-	init.Add(Initializer{
-		"log",
-		initLog,
-		nil,
-	})
-	init.Add(Initializer{
-		"log.metrics",
-		initLogMetrics,
-		[]string{
-			"metrics",
-		},
-	})
-	init.Add(Initializer{
-		"redis",
-		initRedis,
-		[]string{
-			"app-context",
-			"log",
-		},
-	})
-	init.Add(Initializer{
-		"history-db",
-		initHistoryDb,
-		[]string{
-			"app-context",
-			"log",
-		},
-	})
-	init.Add(Initializer{
-		"core-db",
-		initCoreDb,
-		[]string{
-			"app-context",
-			"log",
-		},
-	})
-	init.Add(Initializer{
-		"db-metrics",
-		initDbMetrics,
-		[]string{
-			"metrics",
-			"history-db",
-			"core-db",
-		},
-	})
-	init.Add(Initializer{
-		"web.init",
-		initWeb,
-		[]string{
-			"app-context",
-		},
-	})
-	init.Add(Initializer{
-		"web.metrics",
-		initWebMetrics,
-		[]string{
-			"web.init",
-			"metrics",
-		},
-	})
-	init.Add(Initializer{
-		"web.rate-limiter",
-		initWebRateLimiter,
-		[]string{
-			"web.init",
-		},
-	})
-	init.Add(Initializer{
-		"web.middleware",
-		initWebMiddleware,
-		[]string{
-			"web.init",
-			"web.rate-limiter",
-			"web.metrics",
-		},
-	})
-	init.Add(Initializer{
-		"web.actions",
-		initWebActions,
-		[]string{
-			"web.init",
-		},
-	})
-	init.Add(Initializer{
-		"sentry",
-		initSentryLog,
-		[]string{
-			"log",
-			"app-context",
-		},
-	})
-
 	result := &App{config: config}
-	init.Run(result)
+	appInit.Run(result)
 
 	return result, nil
 }

--- a/init_app_context.go
+++ b/init_app_context.go
@@ -1,0 +1,23 @@
+package horizon
+
+import (
+	"github.com/stellar/go-horizon/log"
+	"golang.org/x/net/context"
+)
+
+func initAppContext(app *App) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, &appContextKey, app)
+
+	ctx = log.Context(ctx, app.log)
+	app.ctx = ctx
+	app.cancel = cancel
+}
+
+func init() {
+	appInit.Add(
+		"app-context",
+		initAppContext,
+		"log",
+	)
+}

--- a/init_db.go
+++ b/init_db.go
@@ -21,3 +21,8 @@ func initCoreDb(app *App) {
 	}
 	app.coreDb = coreDb
 }
+
+func init() {
+	appInit.Add("history-db", initHistoryDb, "app-context", "log")
+	appInit.Add("core-db", initCoreDb, "app-context", "log")
+}

--- a/init_log.go
+++ b/init_log.go
@@ -42,3 +42,8 @@ func initSentryLog(app *App) {
 	app.log.Logger.Hooks.Add(hook)
 
 }
+
+func init() {
+	appInit.Add("log", initLog)
+	appInit.Add("sentry", initSentryLog, "log", "app-context")
+}

--- a/init_metrics.go
+++ b/init_metrics.go
@@ -24,3 +24,18 @@ func initLogMetrics(app *App) {
 		app.metrics.Register(key, meter)
 	}
 }
+
+// initWebMetrics registers the metrics for the web server into the provided
+// app's metrics registry.
+func initWebMetrics(app *App) {
+	app.metrics.Register("requests.total", app.web.requestTimer)
+	app.metrics.Register("requests.succeeded", app.web.successMeter)
+	app.metrics.Register("requests.failed", app.web.failureMeter)
+}
+
+func init() {
+	appInit.Add("metrics", initMetrics)
+	appInit.Add("log.metrics", initLogMetrics, "metrics")
+	appInit.Add("db-metrics", initDbMetrics, "metrics", "history-db", "core-db")
+	appInit.Add("web.metrics", initWebMetrics, "web.init", "metrics")
+}

--- a/init_redis.go
+++ b/init_redis.go
@@ -63,3 +63,7 @@ func pingRedis(c redis.Conn, t time.Time) error {
 	_, err := c.Do("PING")
 	return err
 }
+
+func init() {
+	appInit.Add("redis", initRedis, "app-context", "log")
+}

--- a/init_test.go
+++ b/init_test.go
@@ -1,19 +1,20 @@
 package horizon
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestAppInit(t *testing.T) {
 
-	Convey("AppInit.Run()", t, func() {
-		init := &AppInit{}
+	Convey("initializerSet.Run()", t, func() {
+		init := &initializerSet{}
 
 		Convey("Panics when a cycle is present", func() {
-			init.Add(Initializer{"a", func(app *App) { t.Log("a") }, []string{"b"}})
-			init.Add(Initializer{"b", func(app *App) { t.Log("b") }, []string{"c"}})
-			init.Add(Initializer{"c", func(app *App) { t.Log("c") }, []string{"a"}})
+			init.Add("a", func(app *App) { t.Log("a") }, "b")
+			init.Add("b", func(app *App) { t.Log("b") }, "c")
+			init.Add("c", func(app *App) { t.Log("c") }, "a")
 
 			So(func() {
 				init.Run(&App{})
@@ -23,9 +24,9 @@ func TestAppInit(t *testing.T) {
 		Convey("Runs initializers in the right order", func() {
 			run := []string{}
 
-			init.Add(Initializer{"a", func(app *App) { run = append(run, "a") }, nil})
-			init.Add(Initializer{"b", func(app *App) { run = append(run, "b") }, []string{"a"}})
-			init.Add(Initializer{"c", func(app *App) { run = append(run, "c") }, []string{"b"}})
+			init.Add("a", func(app *App) { run = append(run, "a") })
+			init.Add("b", func(app *App) { run = append(run, "b") }, "a")
+			init.Add("c", func(app *App) { run = append(run, "c") }, "b")
 			init.Run(&App{})
 
 			So(run, ShouldResemble, []string{"a", "b", "c"})
@@ -34,9 +35,9 @@ func TestAppInit(t *testing.T) {
 		Convey("Does not run initializers more than once", func() {
 			run := 0
 
-			init.Add(Initializer{"a", func(app *App) { run++ }, nil})
-			init.Add(Initializer{"b", func(app *App) {}, []string{"a"}})
-			init.Add(Initializer{"c", func(app *App) {}, []string{"a"}})
+			init.Add("a", func(app *App) { run++ })
+			init.Add("b", func(app *App) {}, "a")
+			init.Add("c", func(app *App) {}, "a")
 			init.Run(&App{})
 
 			So(run, ShouldEqual, 1)

--- a/init_web.go
+++ b/init_web.go
@@ -36,14 +36,6 @@ func initWeb(app *App) {
 	}
 }
 
-// initWebMetrics registers the metrics for the web server into the provided
-// app's metrics registry.
-func initWebMetrics(app *App) {
-	app.metrics.Register("requests.total", app.web.requestTimer)
-	app.metrics.Register("requests.succeeded", app.web.successMeter)
-	app.metrics.Register("requests.failed", app.web.failureMeter)
-}
-
 // initWebMiddleware installs the middleware stack used for go-horizon onto the
 // provided app.
 func initWebMiddleware(app *App) {
@@ -148,4 +140,34 @@ func initWebRateLimiter(app *App) {
 func remoteAddrIP(r *http.Request) string {
 	ip := strings.SplitN(r.RemoteAddr, ":", 2)[0]
 	return ip
+}
+
+func init() {
+	appInit.Add(
+		"web.init",
+		initWeb,
+
+		"app-context",
+	)
+
+	appInit.Add(
+		"web.rate-limiter",
+		initWebRateLimiter,
+
+		"web.init",
+	)
+	appInit.Add(
+		"web.middleware",
+		initWebMiddleware,
+
+		"web.init",
+		"web.rate-limiter",
+		"web.metrics",
+	)
+	appInit.Add(
+		"web.actions",
+		initWebActions,
+
+		"web.init",
+	)
 }


### PR DESCRIPTION
This commit changes the horizon initialization system to colocate
initializer declaration with the definition of the initializer’s fun.
Each init_*.go file now uses an `init` func to contribute initializers
to a single `appInit` var.

Additionally, this commit privatizes much of the initialization system.
