### PR TITLE
Added some missing fields to effect resource

### DIFF
--- a/src/github.com/stellar/go-horizon/db/record_effect.go
+++ b/src/github.com/stellar/go-horizon/db/record_effect.go
@@ -14,7 +14,7 @@ var EffectRecordSelect sq.SelectBuilder = sq.
 
 type EffectRecord struct {
 	HistoryAccountID   int64          `db:"history_account_id"`
-	InitiatorAddress   string         `db:"address"`
+	Account            string         `db:"address"`
 	HistoryOperationID int64          `db:"history_operation_id"`
 	Order              int32          `db:"order"`
 	Type               int32          `db:"type"`

--- a/src/github.com/stellar/go-horizon/db/record_effect.go
+++ b/src/github.com/stellar/go-horizon/db/record_effect.go
@@ -8,11 +8,13 @@ import (
 )
 
 var EffectRecordSelect sq.SelectBuilder = sq.
-	Select("heff.*").
-	From("history_effects heff")
+	Select("heff.*, hacc.address").
+	From("history_effects heff").
+	LeftJoin("history_accounts hacc ON hacc.id = heff.history_account_id")
 
 type EffectRecord struct {
 	HistoryAccountID   int64          `db:"history_account_id"`
+	InitiatorAddress   string         `db:"address"`
 	HistoryOperationID int64          `db:"history_operation_id"`
 	Order              int32          `db:"order"`
 	Type               int32          `db:"type"`

--- a/src/github.com/stellar/go-horizon/resource_effect.go
+++ b/src/github.com/stellar/go-horizon/resource_effect.go
@@ -54,9 +54,11 @@ func NewEffectResource(op db.EffectRecord) (EffectResource, error) {
 	result["_links"] = halgo.Links{}.
 		Link("precedes", "/effects?cursor=%s&order=asc", op.PagingToken()).
 		Link("succeeds", "/effects?cursor=%s&order=desc", op.PagingToken()).
+		Link("operation", "/operations/%d", op.HistoryOperationID).
 		Items
 	result["paging_token"] = op.PagingToken()
 	result["type"] = op.Type
+	result["initiator"] = op.InitiatorAddress
 
 	ts, ok := effectResourceTypeNames[op.Type]
 

--- a/src/github.com/stellar/go-horizon/resource_effect.go
+++ b/src/github.com/stellar/go-horizon/resource_effect.go
@@ -58,7 +58,7 @@ func NewEffectResource(op db.EffectRecord) (EffectResource, error) {
 		Items
 	result["paging_token"] = op.PagingToken()
 	result["type"] = op.Type
-	result["initiator"] = op.InitiatorAddress
+	result["account"] = op.Account
 
 	ts, ok := effectResourceTypeNames[op.Type]
 


### PR DESCRIPTION
Added following fields to effect resource:
- `initiator` - user who submitted an operation resulting in an effect,
- link to this `operation`.

It partially clos.es #80:
- We still need to add information about `target` accounts. IMHO, the best idea to achieve this would be to denormalize `history_effects` and insert needed data during an import.
- We can avoid joins by denormalizing `history_effects` table. We can surely do it because existing rows don't change and don't get deleted.
