### PR TITLE
Added created_at field to transaction resource

### DIFF
--- a/src/github.com/stellar/go-horizon/db/record_transaction.go
+++ b/src/github.com/stellar/go-horizon/db/record_transaction.go
@@ -8,13 +8,15 @@ import (
 
 // Provides a squirrel.SelectBuilder upon which you may build actual queries.
 var TransactionRecordSelect sq.SelectBuilder = sq.
-	Select("ht.*").
-	From("history_transactions ht")
+	Select("ht.*, hl.closed_at AS ledger_close_time").
+	From("history_transactions ht").
+	LeftJoin("history_ledgers hl ON ht.ledger_sequence = hl.sequence")
 
 type TransactionRecord struct {
 	HistoryRecord
 	TransactionHash     string         `db:"transaction_hash"`
 	LedgerSequence      int32          `db:"ledger_sequence"`
+	LedgerCloseTime     time.Time      `db:"ledger_close_time"`
 	ApplicationOrder    int32          `db:"application_order"`
 	Account             string         `db:"account"`
 	AccountSequence     int64          `db:"account_sequence"`

--- a/src/github.com/stellar/go-horizon/resource_transaction.go
+++ b/src/github.com/stellar/go-horizon/resource_transaction.go
@@ -2,6 +2,7 @@ package horizon
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jagregory/halgo"
 
@@ -16,6 +17,7 @@ type TransactionResource struct {
 	PagingToken      string `json:"paging_token"`
 	Hash             string `json:"hash"`
 	Ledger           int32  `json:"ledger"`
+	LedgerCloseTime  time.Time `json:"created_at"`
 	Account          string `json:"account"`
 	AccountSequence  int64  `json:"account_sequence"`
 	MaxFee           int32  `json:"max_fee"`
@@ -45,6 +47,7 @@ func NewTransactionResource(tx db.TransactionRecord) TransactionResource {
 		PagingToken:      tx.PagingToken(),
 		Hash:             tx.TransactionHash,
 		Ledger:           tx.LedgerSequence,
+		LedgerCloseTime:  tx.LedgerCloseTime,
 		Account:          tx.Account,
 		AccountSequence:  tx.AccountSequence,
 		MaxFee:           tx.MaxFee,


### PR DESCRIPTION
It partially clos.es #76. We need to add ledger close time to operations and effects but with current databse schema we can't do this without writing some ugly SQL queries. As described in #84 we could make it much simpler with DB denormalization.
