### PR TITLE
Return stellar-core and horizon versions

### DIFF
--- a/src/github.com/stellar/go-horizon/actions_root.go
+++ b/src/github.com/stellar/go-horizon/actions_root.go
@@ -7,28 +7,28 @@ import (
 
 // RootResource is the initial map of links into the api.
 type RootResource struct {
-  HorizonVersion string
-  StellarCoreVersion string
+	HorizonVersion string
+	StellarCoreVersion string
 	halgo.Links
 }
 
 type RootAction struct {
-  Action
+	Action
 }
 
 func (action *RootAction) JSON() {
-  var response = RootResource{
-    HorizonVersion: action.App.horizonVersion,
-    StellarCoreVersion: action.App.coreVersion,
-    Links: halgo.Links{}.
-      Self("/").
-      Link("account", "/accounts/{address}").
-      Link("account_transactions", "/accounts/{address}/transactions{?cursor,limit,order}").
-      Link("transaction", "/transactions/{hash}").
-      Link("transactions", "/transactions{?cursor,limit,order}").
-      Link("order_book", "/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}").
-      Link("metrics", "/metrics").
-      Link("friendbot", "/friendbot{?addr}"),
-  }
-  hal.Render(action.W, response)
+	var response = RootResource{
+		HorizonVersion: action.App.horizonVersion,
+		StellarCoreVersion: action.App.coreVersion,
+		Links: halgo.Links{}.
+			Self("/").
+			Link("account", "/accounts/{address}").
+			Link("account_transactions", "/accounts/{address}/transactions{?cursor,limit,order}").
+			Link("transaction", "/transactions/{hash}").
+			Link("transactions", "/transactions{?cursor,limit,order}").
+			Link("order_book", "/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}").
+			Link("metrics", "/metrics").
+			Link("friendbot", "/friendbot{?addr}"),
+	}
+	hal.Render(action.W, response)
 }

--- a/src/github.com/stellar/go-horizon/actions_root.go
+++ b/src/github.com/stellar/go-horizon/actions_root.go
@@ -1,29 +1,34 @@
 package horizon
 
 import (
-	"net/http"
-
 	"github.com/jagregory/halgo"
 	"github.com/stellar/go-horizon/render/hal"
 )
 
 // RootResource is the initial map of links into the api.
 type RootResource struct {
+  HorizonVersion string
+  StellarCoreVersion string
 	halgo.Links
 }
 
-var globalRootResource = RootResource{
-	Links: halgo.Links{}.
-		Self("/").
-		Link("account", "/accounts/{address}").
-		Link("account_transactions", "/accounts/{address}/transactions{?cursor,limit,order}").
-		Link("transaction", "/transactions/{hash}").
-		Link("transactions", "/transactions{?cursor,limit,order}").
-		Link("order_book", "/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}").
-		Link("metrics", "/metrics").
-		Link("friendbot", "/friendbot{?addr}"),
+type RootAction struct {
+  Action
 }
 
-func rootAction(w http.ResponseWriter, r *http.Request) {
-	hal.Render(w, globalRootResource)
+func (action *RootAction) JSON() {
+  var response = RootResource{
+    HorizonVersion: action.App.horizonVersion,
+    StellarCoreVersion: action.App.coreVersion,
+    Links: halgo.Links{}.
+      Self("/").
+      Link("account", "/accounts/{address}").
+      Link("account_transactions", "/accounts/{address}/transactions{?cursor,limit,order}").
+      Link("transaction", "/transactions/{hash}").
+      Link("transactions", "/transactions{?cursor,limit,order}").
+      Link("order_book", "/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}").
+      Link("metrics", "/metrics").
+      Link("friendbot", "/friendbot{?addr}"),
+  }
+  hal.Render(action.W, response)
 }

--- a/src/github.com/stellar/go-horizon/actions_root.go
+++ b/src/github.com/stellar/go-horizon/actions_root.go
@@ -7,9 +7,9 @@ import (
 
 // RootResource is the initial map of links into the api.
 type RootResource struct {
+	halgo.Links
 	HorizonVersion string
 	StellarCoreVersion string
-	halgo.Links
 }
 
 type RootAction struct {

--- a/src/github.com/stellar/go-horizon/app.go
+++ b/src/github.com/stellar/go-horizon/app.go
@@ -31,12 +31,12 @@ type App struct {
 	redis      *redis.Pool
 	log        *logrus.Entry
 	logMetrics *log.Metrics
-  coreVersion    string
-  horizonVersion string
+	coreVersion    string
+	horizonVersion string
 }
 
 func SetVersion(v string) {
-  version = v;
+	version = v;
 }
 
 // AppFromContext retrieves a *App from the context tree.
@@ -49,7 +49,7 @@ func AppFromContext(ctx context.Context) (*App, bool) {
 func NewApp(config Config) (*App, error) {
 
 	result := &App{config: config}
-  result.horizonVersion = version
+	result.horizonVersion = version
 	appInit.Run(result)
 
 	return result, nil

--- a/src/github.com/stellar/go-horizon/app.go
+++ b/src/github.com/stellar/go-horizon/app.go
@@ -29,6 +29,8 @@ type App struct {
 	redis      *redis.Pool
 	log        *logrus.Entry
 	logMetrics *log.Metrics
+  coreVersion    string
+  horizonVersion string
 }
 
 // AppFromContext retrieves a *App from the context tree.

--- a/src/github.com/stellar/go-horizon/app.go
+++ b/src/github.com/stellar/go-horizon/app.go
@@ -40,9 +40,10 @@ func AppFromContext(ctx context.Context) (*App, bool) {
 }
 
 // NewApp constructs an new App instance from the provided config.
-func NewApp(config Config) (*App, error) {
+func NewApp(config Config, version string) (*App, error) {
 
 	result := &App{config: config}
+  result.horizonVersion = version
 	appInit.Run(result)
 
 	return result, nil

--- a/src/github.com/stellar/go-horizon/app.go
+++ b/src/github.com/stellar/go-horizon/app.go
@@ -18,7 +18,7 @@ import (
 
 var appContextKey = 0
 // You can override this variable using: gb build -ldflags "-X main.version aabbccdd"
-var version = "version"
+var version = ""
 
 type App struct {
 	config     Config

--- a/src/github.com/stellar/go-horizon/app.go
+++ b/src/github.com/stellar/go-horizon/app.go
@@ -17,6 +17,8 @@ import (
 )
 
 var appContextKey = 0
+// You can override this variable using: gb build -ldflags "-X main.version aabbccdd"
+var version = "version"
 
 type App struct {
 	config     Config
@@ -33,6 +35,10 @@ type App struct {
   horizonVersion string
 }
 
+func SetVersion(v string) {
+  version = v;
+}
+
 // AppFromContext retrieves a *App from the context tree.
 func AppFromContext(ctx context.Context) (*App, bool) {
 	a, ok := ctx.Value(&appContextKey).(*App)
@@ -40,7 +46,7 @@ func AppFromContext(ctx context.Context) (*App, bool) {
 }
 
 // NewApp constructs an new App instance from the provided config.
-func NewApp(config Config, version string) (*App, error) {
+func NewApp(config Config) (*App, error) {
 
 	result := &App{config: config}
   result.horizonVersion = version

--- a/src/github.com/stellar/go-horizon/cmd/horizon/main.go
+++ b/src/github.com/stellar/go-horizon/cmd/horizon/main.go
@@ -15,6 +15,8 @@ import (
 
 var app *horizon.App
 var rootCmd *cobra.Command
+// You can override this variable using: gb build -ldflags "-X main.horizonVersion aabbccdd"
+var horizonVersion = "beta"
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
@@ -158,7 +160,7 @@ func run(cmd *cobra.Command, args []string) {
 		LogglyHost:             viper.GetString("loggly-host"),
 	}
 
-	app, err = horizon.NewApp(config)
+	app, err = horizon.NewApp(config, horizonVersion)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/src/github.com/stellar/go-horizon/cmd/horizon/main.go
+++ b/src/github.com/stellar/go-horizon/cmd/horizon/main.go
@@ -18,9 +18,9 @@ var rootCmd *cobra.Command
 var version string
 
 func main() {
-  if version != "" {
-    horizon.SetVersion(version)
-  }
+	if version != "" {
+		horizon.SetVersion(version)
+	}
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	rootCmd.Execute()
 }

--- a/src/github.com/stellar/go-horizon/cmd/horizon/main.go
+++ b/src/github.com/stellar/go-horizon/cmd/horizon/main.go
@@ -15,10 +15,12 @@ import (
 
 var app *horizon.App
 var rootCmd *cobra.Command
-// You can override this variable using: gb build -ldflags "-X main.horizonVersion aabbccdd"
-var horizonVersion = "beta"
+var version string
 
 func main() {
+  if version != "" {
+    horizon.SetVersion(version)
+  }
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	rootCmd.Execute()
 }
@@ -160,7 +162,7 @@ func run(cmd *cobra.Command, args []string) {
 		LogglyHost:             viper.GetString("loggly-host"),
 	}
 
-	app, err = horizon.NewApp(config, horizonVersion)
+	app, err = horizon.NewApp(config)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/src/github.com/stellar/go-horizon/init_versions.go
+++ b/src/github.com/stellar/go-horizon/init_versions.go
@@ -1,0 +1,48 @@
+package horizon
+
+import (
+  "fmt"
+  "io/ioutil"
+  "net/http"
+  "os/exec"
+  "strings"
+  "encoding/json"
+)
+
+func initStellarCoreVersion(app *App) {
+  if app.config.StellarCoreUrl == "" {
+    return
+  }
+
+  resp, err := http.Get(fmt.Sprint(app.config.StellarCoreUrl,"/info"))
+
+  if err != nil {
+    app.log.Panic(app.ctx, err)
+  }
+
+  defer resp.Body.Close()
+  contents, err := ioutil.ReadAll(resp.Body)
+  if err != nil {
+    app.log.Panic(app.ctx, err)
+  }
+
+  var responseJson map[string]*json.RawMessage
+  err = json.Unmarshal(contents, &responseJson)
+
+  var serverInfo map[string]string
+  err = json.Unmarshal(*responseJson["info"], &serverInfo)
+  app.coreVersion = serverInfo["build"]
+}
+
+func initHorizonVersion(app *App) {
+  version, err := exec.Command("git", "describe", "--always", "--dirty", "--tags").Output()
+  if err != nil {
+    app.log.Panic(app.ctx, err)
+  }
+  app.horizonVersion = strings.TrimSpace(string(version))
+}
+
+func init() {
+  appInit.Add("stellarCoreVersion", initStellarCoreVersion, "app-context", "log")
+  appInit.Add("horizonVersion", initHorizonVersion, "app-context", "log")
+}

--- a/src/github.com/stellar/go-horizon/init_versions.go
+++ b/src/github.com/stellar/go-horizon/init_versions.go
@@ -4,8 +4,6 @@ import (
   "fmt"
   "io/ioutil"
   "net/http"
-  "os/exec"
-  "strings"
   "encoding/json"
 )
 
@@ -34,15 +32,6 @@ func initStellarCoreVersion(app *App) {
   app.coreVersion = serverInfo["build"]
 }
 
-func initHorizonVersion(app *App) {
-  version, err := exec.Command("git", "describe", "--always", "--dirty", "--tags").Output()
-  if err != nil {
-    app.log.Panic(app.ctx, err)
-  }
-  app.horizonVersion = strings.TrimSpace(string(version))
-}
-
 func init() {
   appInit.Add("stellarCoreVersion", initStellarCoreVersion, "app-context", "log")
-  appInit.Add("horizonVersion", initHorizonVersion, "app-context", "log")
 }

--- a/src/github.com/stellar/go-horizon/init_versions.go
+++ b/src/github.com/stellar/go-horizon/init_versions.go
@@ -1,10 +1,10 @@
 package horizon
 
 import (
-  "fmt"
-  "io/ioutil"
-  "net/http"
-  "encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"encoding/json"
 )
 
 func initStellarCoreVersion(app *App) {

--- a/src/github.com/stellar/go-horizon/init_versions.go
+++ b/src/github.com/stellar/go-horizon/init_versions.go
@@ -8,30 +8,30 @@ import (
 )
 
 func initStellarCoreVersion(app *App) {
-  if app.config.StellarCoreUrl == "" {
-    return
-  }
+	if app.config.StellarCoreUrl == "" {
+		return
+	}
 
-  resp, err := http.Get(fmt.Sprint(app.config.StellarCoreUrl,"/info"))
+	resp, err := http.Get(fmt.Sprint(app.config.StellarCoreUrl,"/info"))
 
-  if err != nil {
-    app.log.Panic(app.ctx, err)
-  }
+	if err != nil {
+		app.log.Panic(app.ctx, err)
+	}
 
-  defer resp.Body.Close()
-  contents, err := ioutil.ReadAll(resp.Body)
-  if err != nil {
-    app.log.Panic(app.ctx, err)
-  }
+	defer resp.Body.Close()
+	contents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		app.log.Panic(app.ctx, err)
+	}
 
-  var responseJson map[string]*json.RawMessage
-  err = json.Unmarshal(contents, &responseJson)
+	var responseJson map[string]*json.RawMessage
+	err = json.Unmarshal(contents, &responseJson)
 
-  var serverInfo map[string]string
-  err = json.Unmarshal(*responseJson["info"], &serverInfo)
-  app.coreVersion = serverInfo["build"]
+	var serverInfo map[string]string
+	err = json.Unmarshal(*responseJson["info"], &serverInfo)
+	app.coreVersion = serverInfo["build"]
 }
 
 func init() {
-  appInit.Add("stellarCoreVersion", initStellarCoreVersion, "app-context", "log")
+	appInit.Add("stellarCoreVersion", initStellarCoreVersion, "app-context", "log")
 }

--- a/src/github.com/stellar/go-horizon/init_web.go
+++ b/src/github.com/stellar/go-horizon/init_web.go
@@ -70,7 +70,7 @@ func initWebMiddleware(app *App) {
 // provided app.  All route registration should be implemented here.
 func initWebActions(app *App) {
 	r := app.web.router
-	r.Get("/", rootAction)
+	r.Get("/", &RootAction{})
 	r.Get("/metrics", &MetricsAction{})
 
 	// ledger actions

--- a/src/github.com/stellar/go-horizon/main_generated.go
+++ b/src/github.com/stellar/go-horizon/main_generated.go
@@ -7,9 +7,9 @@ import (
 
 // ServeHTTPC is a method for web.Handler
 func (action RootAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-  ap := &action.Action
-  ap.Prepare(c, w, r)
-  ap.Execute(&action)
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
 }
 
 // ServeHTTPC is a method for web.Handler

--- a/src/github.com/stellar/go-horizon/main_generated.go
+++ b/src/github.com/stellar/go-horizon/main_generated.go
@@ -6,6 +6,13 @@ import (
 )
 
 // ServeHTTPC is a method for web.Handler
+func (action RootAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+  ap := &action.Action
+  ap.Prepare(c, w, r)
+  ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
 func (action PaymentsIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)


### PR DESCRIPTION
This PR adds `HorizonVersion` and `StellarCoreVersion` to root resource.

Close #73.
