### PR TITLE
Added account info to /accounts endpoint

### DIFF
--- a/src/github.com/stellar/go-horizon/db/query_account_by_address.go
+++ b/src/github.com/stellar/go-horizon/db/query_account_by_address.go
@@ -31,6 +31,12 @@ func (q AccountByAddressQuery) Select(ctx context.Context, dest interface{}) err
 	if err != nil {
 		return err
 	}
+
+	cq = CoreSignersByAddressQuery{q.Core, q.Address}
+	err = Select(ctx, cq, &result.Signers)
+	if err != nil {
+		return err
+	}
 	setOn([]AccountRecord{result}, dest)
 	return nil
 }

--- a/src/github.com/stellar/go-horizon/db/query_core_signers_by_address.go
+++ b/src/github.com/stellar/go-horizon/db/query_core_signers_by_address.go
@@ -1,0 +1,13 @@
+package db
+
+import "golang.org/x/net/context"
+
+type CoreSignersByAddressQuery struct {
+	SqlQuery
+	Address string
+}
+
+func (q CoreSignersByAddressQuery) Select(ctx context.Context, dest interface{}) error {
+	sql := CoreSignerRecordSelect.Where("accountid = ?", q.Address)
+	return q.SqlQuery.Select(ctx, sql, dest)
+}

--- a/src/github.com/stellar/go-horizon/db/record_account.go
+++ b/src/github.com/stellar/go-horizon/db/record_account.go
@@ -4,5 +4,6 @@ type AccountRecord struct {
 	HistoryAccountRecord
 	CoreAccountRecord
 	Trustlines []CoreTrustlineRecord
+	Signers []CoreSignerRecord
 }
 

--- a/src/github.com/stellar/go-horizon/db/record_core_account.go
+++ b/src/github.com/stellar/go-horizon/db/record_core_account.go
@@ -21,8 +21,8 @@ var CoreAccountRecordSelect sq.SelectBuilder = sq.Select(
 ).From("accounts a")
 
 const (
-   FlagAuthRequired = 1 << iota
-   FlagAuthRevocable = 1 << iota
+	FlagAuthRequired = 1 << iota
+	FlagAuthRevocable = 1 << iota
 )
 
 // A row of data from the `accounts` table from stellar-core

--- a/src/github.com/stellar/go-horizon/db/record_core_account.go
+++ b/src/github.com/stellar/go-horizon/db/record_core_account.go
@@ -1,8 +1,12 @@
 package db
 
 import (
+	"strings"
+	"encoding/base64"
+
 	"github.com/guregu/null"
 	sq "github.com/lann/squirrel"
+	"github.com/stellar/go-stellar-base/xdr"
 )
 
 var CoreAccountRecordSelect sq.SelectBuilder = sq.Select(
@@ -16,6 +20,11 @@ var CoreAccountRecordSelect sq.SelectBuilder = sq.Select(
 	"a.flags",
 ).From("accounts a")
 
+const (
+   FlagAuthRequired = 1 << iota
+   FlagAuthRevocable = 1 << iota
+)
+
 // A row of data from the `accounts` table from stellar-core
 type CoreAccountRecord struct {
 	Accountid     string
@@ -26,4 +35,20 @@ type CoreAccountRecord struct {
 	HomeDomain    null.String
 	Thresholds    string
 	Flags         int32
+}
+
+func (ac CoreAccountRecord) IsAuthRequired() bool {
+	return (ac.Flags & FlagAuthRequired) != 0
+}
+
+func (ac CoreAccountRecord) IsAuthRevocable() bool {
+	return (ac.Flags & FlagAuthRevocable) != 0
+}
+
+func (ac CoreAccountRecord) DecodeThresholds() (xdr.Thresholds, error) {
+	reader := strings.NewReader(ac.Thresholds)
+	b64r := base64.NewDecoder(base64.StdEncoding, reader)
+	var xdrThresholds xdr.Thresholds
+	_, err := xdr.Unmarshal(b64r, &xdrThresholds)
+	return xdrThresholds, err
 }

--- a/src/github.com/stellar/go-horizon/db/record_core_account.go
+++ b/src/github.com/stellar/go-horizon/db/record_core_account.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"database/sql"
+	"github.com/guregu/null"
 	sq "github.com/lann/squirrel"
 )
 
@@ -11,6 +11,7 @@ var CoreAccountRecordSelect sq.SelectBuilder = sq.Select(
 	"a.seqnum",
 	"a.numsubentries",
 	"a.inflationdest",
+	"a.homedomain",
 	"a.thresholds",
 	"a.flags",
 ).From("accounts a")
@@ -21,7 +22,8 @@ type CoreAccountRecord struct {
 	Balance       int64
 	Seqnum        int64
 	Numsubentries int32
-	Inflationdest sql.NullString
+	Inflationdest null.String
+	HomeDomain    null.String
 	Thresholds    string
 	Flags         int32
 }

--- a/src/github.com/stellar/go-horizon/db/record_core_signer.go
+++ b/src/github.com/stellar/go-horizon/db/record_core_signer.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	sq "github.com/lann/squirrel"
+)
+
+var CoreSignerRecordSelect sq.SelectBuilder = sq.Select(
+	"si.accountid",
+	"si.publickey",
+	"si.weight",
+).From("signers si")
+
+// A row of data from the `signers` table from stellar-core
+type CoreSignerRecord struct {
+	Accountid string
+	Publickey string
+	Weight    int32
+}

--- a/src/github.com/stellar/go-horizon/resource_account.go
+++ b/src/github.com/stellar/go-horizon/resource_account.go
@@ -2,7 +2,10 @@ package horizon
 
 import (
 	"fmt"
+	"strings"
+	"encoding/base64"
 
+	"github.com/guregu/null"
 	"github.com/jagregory/halgo"
 	"github.com/stellar/go-horizon/db"
 	"github.com/stellar/go-horizon/render/hal"
@@ -13,11 +16,17 @@ import (
 // AccountResource is the summary of an account
 type AccountResource struct {
 	halgo.Links
-	ID          string            `json:"id"`
-	PagingToken string            `json:"paging_token"`
-	Address     string            `json:"address"`
-	Sequence    int64             `json:"sequence"`
-	Balances    []BalanceResource `json:"balances"`
+	ID            string             `json:"id"`
+	PagingToken   string             `json:"paging_token"`
+	Address       string             `json:"address"`
+	Sequence      int64              `json:"sequence"`
+	Numsubentries int32              `json:"numsubentries"`
+	InflationDest null.String        `json:"inflation_destination"`
+	HomeDomain    null.String        `json:"home_domain"`
+	Thresholds    map[string]byte    `json:"thresholds"`
+	Flags         map[string]bool    `json:"flags"`
+	Balances      []BalanceResource  `json:"balances"`
+	Signers       []SignerResource   `json:"signers"`
 }
 
 // BalanceResource represents an accounts holdings for a single currency type
@@ -28,6 +37,11 @@ type BalanceResource struct {
 	Code   string `json:"asset_code,omitempty"`
 	Issuer string `json:"issuer,omitempty"`
 	Limit  string `json:"limit,omitempty"`
+}
+
+type SignerResource struct {
+	Address string `json:"address"`
+	Weight  int32  `json:"weight"`
 }
 
 // NewAccountRsource creates a new AccountResource from a provided db.CoreAccountRecord and
@@ -62,6 +76,33 @@ func NewAccountResource(ac db.AccountRecord) AccountResource {
 	// add native balance
 	balances[len(ac.Trustlines)] = BalanceResource{Type: "native", Balance: AmountToString(ac.Balance)}
 
+	// signers
+	signers := make([]SignerResource, len(ac.Signers))
+
+	for i, s := range ac.Signers {
+		signers[i] = SignerResource{Address: s.Publickey, Weight: s.Weight}
+	}
+
+	// thresholds
+	reader := strings.NewReader(ac.Thresholds)
+	b64r := base64.NewDecoder(base64.StdEncoding, reader)
+	var xdrThresholds xdr.Thresholds
+	_, err := xdr.Unmarshal(b64r, &xdrThresholds)
+
+	var thresholdsMap map[string]byte
+	if err == nil {
+		thresholdsMap = make(map[string]byte)
+		thresholdsMap["threshold_master_weight"] = xdrThresholds[0]
+		thresholdsMap["threshold_low"] = xdrThresholds[1]
+		thresholdsMap["threshold_med"] = xdrThresholds[2]
+		thresholdsMap["threshold_high"] = xdrThresholds[3]
+	}
+
+	// flags
+	flagsMap := make(map[string]bool)
+	flagsMap["auth_required_flag"] = IsTrue(ac.Flags & 1)
+	flagsMap["auth_revocable_flag"] = IsTrue(ac.Flags & 2)
+
 	return AccountResource{
 		Links: halgo.Links{}.
 			Self(self).
@@ -69,11 +110,17 @@ func NewAccountResource(ac db.AccountRecord) AccountResource {
 			Link("operations", "%s/operations/%s", self, hal.StandardPagingOptions).
 			Link("effects", "%s/effects/%s", self, hal.StandardPagingOptions).
 			Link("offers", "%s/offers/%s", self, hal.StandardPagingOptions),
-		ID:          address,
-		PagingToken: ac.PagingToken(),
-		Address:     address,
-		Sequence:    ac.Seqnum,
-		Balances:    balances,
+		ID:            address,
+		PagingToken:   ac.PagingToken(),
+		Address:       address,
+		Sequence:      ac.Seqnum,
+		Numsubentries: ac.Numsubentries,
+		InflationDest: ac.Inflationdest,
+		HomeDomain:    ac.HomeDomain,
+		Thresholds:    thresholdsMap,
+		Flags:         flagsMap,
+		Balances:      balances,
+		Signers:       signers,
 	}
 }
 
@@ -81,4 +128,11 @@ func AmountToString(amount int64) string {
 	whole := amount / stellarbase.One
 	frac := amount % stellarbase.One
 	return fmt.Sprintf("%d.%07d", whole, frac)
+}
+
+func IsTrue(value int32) bool {
+  if value != 0 {
+    return true
+  }
+  return false
 }

--- a/src/github.com/stellar/go-horizon/resource_account.go
+++ b/src/github.com/stellar/go-horizon/resource_account.go
@@ -43,14 +43,14 @@ type SignerResource struct {
 }
 
 type ThresholdsResource struct {
-    LowThreshold  byte `json:"low_threshold"`
-    MedThreshold  byte `json:"med_threshold"`
-    HighThreshold byte `json:"high_threshold"`
+	LowThreshold  byte `json:"low_threshold"`
+	MedThreshold  byte `json:"med_threshold"`
+	HighThreshold byte `json:"high_threshold"`
 }
 
 type FlagsResource struct {
-    AuthRequired  bool `json:"auth_required"`
-    AuthRevocable bool `json:"auth_revocable"`
+	AuthRequired  bool `json:"auth_required"`
+	AuthRevocable bool `json:"auth_revocable"`
 }
 
 // NewAccountRsource creates a new AccountResource from a provided db.CoreAccountRecord and

--- a/vendor/src/github.com/guregu/null/LICENSE
+++ b/vendor/src/github.com/guregu/null/LICENSE
@@ -1,0 +1,10 @@
+Copyright (c) 2014, Greg Roseberry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/src/github.com/guregu/null/README.md
+++ b/vendor/src/github.com/guregu/null/README.md
@@ -1,0 +1,58 @@
+## null [![GoDoc](https://godoc.org/github.com/guregu/null?status.svg)](https://godoc.org/github.com/guregu/null) [![Coverage](http://gocover.io/_badge/github.com/guregu/null)](http://gocover.io/github.com/guregu/null)
+`import "gopkg.in/guregu/null.v2"`
+
+null is a library with reasonable options for dealing with nullable SQL and JSON values
+
+There are two packages: `null` and its subpackage `zero`. 
+
+Types in `null` will only be considered null on null input, and will JSON encode to `null`. If you need zero and null be considered separate values, use these.
+
+Types in `zero` are treated like zero values in Go: blank string input will produce a null `zero.String`, and null Strings will JSON encode to `""`. If you need zero and null treated the same, use these.
+
+All types implement `sql.Scanner` and `driver.Valuer`, so you can use this library in place of `sql.NullXXX`. All types also implement: `encoding.TextMarshaler`, `encoding.TextUnmarshaler`, `json.Marshaler`, and `json.Unmarshaler`. 
+
+#### zero.String
+A nullable string.
+
+Will marshal to a blank string if null. Blank string input produces a null String. In other words, null values and empty values are considered equivalent. Can unmarshal from `sql.NullString` JSON input. 
+
+#### zero.Int
+A nullable int64.
+
+Will marshal to 0 if null. Blank string or 0 input produces a null Int. In other words, null values and empty values are considered equivalent. Can unmarshal from `sql.NullInt64` JSON input. 
+
+#### zero.Float
+A nullable float64.
+
+Will marshal to 0 if null. Blank string or 0 input produces a null Float. In other words, null values and empty values are considered equivalent. Can unmarshal from `sql.NullFloat64` JSON input. 
+
+#### zero.Bool
+A nullable bool.
+
+Will marshal to false if null. Blank string or false input produces a null Float. In other words, null values and empty values are considered equivalent. Can unmarshal from `sql.NullBool` JSON input. 
+
+#### null.String
+An even nuller nullable string. 
+
+Unlike `zero.String`, `null.String` will marshal to null if null. Zero (blank) input will not produce a null String. Can unmarshal from `sql.NullString` JSON input. 
+
+#### null.Int
+An even nuller nullable int64. 
+
+Unlike `zero.Int`, `null.Int` will marshal to null if null. Zero input will not produce a null Int. Can unmarshal from `sql.NullInt64` JSON input. 
+
+#### null.Float
+An even nuller nullable float64. 
+
+Unlike `zero.Float`, `null.Float` will marshal to null if null. Zero input will not produce a null Float. Can unmarshal from `sql.NullFloat64` JSON input. 
+
+#### null.Bool
+An even nuller nullable float64. 
+
+Unlike `zero.Bool`, `null.Bool` will marshal to null if null. False input will not produce a null Bool. Can unmarshal from `sql.NullBool` JSON input. 
+
+### Bugs
+`json`'s `",omitempty"` struct tag does not work correctly right now. It will never omit a null or empty String. This should be [fixed eventually](https://github.com/golang/go/issues/4357).
+
+### License
+BSD

--- a/vendor/src/github.com/guregu/null/bool.go
+++ b/vendor/src/github.com/guregu/null/bool.go
@@ -1,0 +1,127 @@
+package null
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Bool is a nullable bool.
+// It does not consider false values to be null.
+// It will decode to null, not false, if null.
+type Bool struct {
+	sql.NullBool
+}
+
+// NewBool creates a new Bool
+func NewBool(b bool, valid bool) Bool {
+	return Bool{
+		NullBool: sql.NullBool{
+			Bool:  b,
+			Valid: valid,
+		},
+	}
+}
+
+// BoolFrom creates a new Bool that will always be valid.
+func BoolFrom(b bool) Bool {
+	return NewBool(b, true)
+}
+
+// BoolFromPtr creates a new Bool that will be null if f is nil.
+func BoolFromPtr(b *bool) Bool {
+	if b == nil {
+		return NewBool(false, false)
+	}
+	return NewBool(*b, true)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports number and null input.
+// 0 will not be considered a null Bool.
+// It also supports unmarshalling a sql.NullBool.
+func (b *Bool) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch x := v.(type) {
+	case bool:
+		b.Bool = x
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &b.NullBool)
+	case nil:
+		b.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.Bool", reflect.TypeOf(v).Name())
+	}
+	b.Valid = err == nil
+	return err
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null Bool if the input is a blank or not an integer.
+// It will return an error if the input is not an integer, blank, or "null".
+func (b *Bool) UnmarshalText(text []byte) error {
+	str := string(text)
+	switch str {
+	case "", "null":
+		b.Valid = false
+		return nil
+	case "true":
+		b.Bool = true
+	case "false":
+		b.Bool = false
+	default:
+		b.Valid = false
+		return errors.New("invalid input:" + str)
+	}
+	b.Valid = true
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this Bool is null.
+func (b Bool) MarshalJSON() ([]byte, error) {
+	if !b.Valid {
+		return []byte("null"), nil
+	}
+	if !b.Bool {
+		return []byte("false"), nil
+	}
+	return []byte("true"), nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a blank string if this Bool is null.
+func (b Bool) MarshalText() ([]byte, error) {
+	if !b.Valid {
+		return []byte{}, nil
+	}
+	if !b.Bool {
+		return []byte("false"), nil
+	}
+	return []byte("true"), nil
+}
+
+// SetValid changes this Bool's value and also sets it to be non-null.
+func (b *Bool) SetValid(v bool) {
+	b.Bool = v
+	b.Valid = true
+}
+
+// Ptr returns a pointer to this Bool's value, or a nil pointer if this Bool is null.
+func (b Bool) Ptr() *bool {
+	if !b.Valid {
+		return nil
+	}
+	return &b.Bool
+}
+
+// IsZero returns true for invalid Bools, for future omitempty support (Go 1.4?)
+// A non-null Bool with a 0 value will not be considered zero.
+func (b Bool) IsZero() bool {
+	return !b.Valid
+}

--- a/vendor/src/github.com/guregu/null/bool_test.go
+++ b/vendor/src/github.com/guregu/null/bool_test.go
@@ -1,0 +1,195 @@
+package null
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	boolJSON     = []byte(`true`)
+	falseJSON    = []byte(`false`)
+	nullBoolJSON = []byte(`{"Bool":true,"Valid":true}`)
+)
+
+func TestBoolFrom(t *testing.T) {
+	b := BoolFrom(true)
+	assertBool(t, b, "BoolFrom()")
+
+	zero := BoolFrom(false)
+	if !zero.Valid {
+		t.Error("BoolFrom(false)", "is invalid, but should be valid")
+	}
+}
+
+func TestBoolFromPtr(t *testing.T) {
+	n := true
+	bptr := &n
+	b := BoolFromPtr(bptr)
+	assertBool(t, b, "BoolFromPtr()")
+
+	null := BoolFromPtr(nil)
+	assertNullBool(t, null, "BoolFromPtr(nil)")
+}
+
+func TestUnmarshalBool(t *testing.T) {
+	var b Bool
+	err := json.Unmarshal(boolJSON, &b)
+	maybePanic(err)
+	assertBool(t, b, "bool json")
+
+	var nb Bool
+	err = json.Unmarshal(nullBoolJSON, &nb)
+	maybePanic(err)
+	assertBool(t, nb, "sq.NullBool json")
+
+	var null Bool
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullBool(t, null, "null json")
+
+	var badType Bool
+	err = json.Unmarshal(intJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullBool(t, badType, "wrong type json")
+}
+
+func TestTextUnmarshalBool(t *testing.T) {
+	var b Bool
+	err := b.UnmarshalText([]byte("true"))
+	maybePanic(err)
+	assertBool(t, b, "UnmarshalText() bool")
+
+	var zero Bool
+	err = zero.UnmarshalText([]byte("false"))
+	maybePanic(err)
+	assertFalseBool(t, zero, "UnmarshalText() false")
+
+	var blank Bool
+	err = blank.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullBool(t, blank, "UnmarshalText() empty bool")
+
+	var null Bool
+	err = null.UnmarshalText([]byte("null"))
+	maybePanic(err)
+	assertNullBool(t, null, `UnmarshalText() "null"`)
+
+	var invalid Bool
+	err = invalid.UnmarshalText([]byte(":D"))
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullBool(t, invalid, "invalid json")
+}
+
+func TestMarshalBool(t *testing.T) {
+	b := BoolFrom(true)
+	data, err := json.Marshal(b)
+	maybePanic(err)
+	assertJSONEquals(t, data, "true", "non-empty json marshal")
+
+	zero := NewBool(false, true)
+	data, err = json.Marshal(zero)
+	maybePanic(err)
+	assertJSONEquals(t, data, "false", "zero json marshal")
+
+	// invalid values should be encoded as null
+	null := NewBool(false, false)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "null", "null json marshal")
+}
+
+func TestMarshalBoolText(t *testing.T) {
+	b := BoolFrom(true)
+	data, err := b.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "true", "non-empty text marshal")
+
+	zero := NewBool(false, true)
+	data, err = zero.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "false", "zero text marshal")
+
+	// invalid values should be encoded as null
+	null := NewBool(false, false)
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "", "null text marshal")
+}
+
+func TestBoolPointer(t *testing.T) {
+	b := BoolFrom(true)
+	ptr := b.Ptr()
+	if *ptr != true {
+		t.Errorf("bad %s bool: %#v ≠ %v\n", "pointer", ptr, true)
+	}
+
+	null := NewBool(false, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s bool: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestBoolIsZero(t *testing.T) {
+	b := BoolFrom(true)
+	if b.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := NewBool(false, false)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	zero := NewBool(false, true)
+	if zero.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+}
+
+func TestBoolSetValid(t *testing.T) {
+	change := NewBool(false, false)
+	assertNullBool(t, change, "SetValid()")
+	change.SetValid(true)
+	assertBool(t, change, "SetValid()")
+}
+
+func TestBoolScan(t *testing.T) {
+	var b Bool
+	err := b.Scan(true)
+	maybePanic(err)
+	assertBool(t, b, "scanned bool")
+
+	var null Bool
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullBool(t, null, "scanned null")
+}
+
+func assertBool(t *testing.T, b Bool, from string) {
+	if b.Bool != true {
+		t.Errorf("bad %s bool: %v ≠ %v\n", from, b.Bool, true)
+	}
+	if !b.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertFalseBool(t *testing.T, b Bool, from string) {
+	if b.Bool != false {
+		t.Errorf("bad %s bool: %v ≠ %v\n", from, b.Bool, false)
+	}
+	if !b.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullBool(t *testing.T, b Bool, from string) {
+	if b.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}

--- a/vendor/src/github.com/guregu/null/float.go
+++ b/vendor/src/github.com/guregu/null/float.go
@@ -1,0 +1,115 @@
+package null
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// Float is a nullable float64.
+// It does not consider zero values to be null.
+// It will decode to null, not zero, if null.
+type Float struct {
+	sql.NullFloat64
+}
+
+// NewFloat creates a new Float
+func NewFloat(f float64, valid bool) Float {
+	return Float{
+		NullFloat64: sql.NullFloat64{
+			Float64: f,
+			Valid:   valid,
+		},
+	}
+}
+
+// FloatFrom creates a new Float that will always be valid.
+func FloatFrom(f float64) Float {
+	return NewFloat(f, true)
+}
+
+// FloatFromPtr creates a new Float that be null if f is nil.
+func FloatFromPtr(f *float64) Float {
+	if f == nil {
+		return NewFloat(0, false)
+	}
+	return NewFloat(*f, true)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports number and null input.
+// 0 will not be considered a null Float.
+// It also supports unmarshalling a sql.NullFloat64.
+func (f *Float) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch x := v.(type) {
+	case float64:
+		f.Float64 = float64(x)
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &f.NullFloat64)
+	case nil:
+		f.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.Float", reflect.TypeOf(v).Name())
+	}
+	f.Valid = err == nil
+	return err
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null Float if the input is a blank or not an integer.
+// It will return an error if the input is not an integer, blank, or "null".
+func (f *Float) UnmarshalText(text []byte) error {
+	str := string(text)
+	if str == "" || str == "null" {
+		f.Valid = false
+		return nil
+	}
+	var err error
+	f.Float64, err = strconv.ParseFloat(string(text), 64)
+	f.Valid = err == nil
+	return err
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this Float is null.
+func (f Float) MarshalJSON() ([]byte, error) {
+	if !f.Valid {
+		return []byte("null"), nil
+	}
+	return []byte(strconv.FormatFloat(f.Float64, 'f', -1, 64)), nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a blank string if this Float is null.
+func (f Float) MarshalText() ([]byte, error) {
+	if !f.Valid {
+		return []byte{}, nil
+	}
+	return []byte(strconv.FormatFloat(f.Float64, 'f', -1, 64)), nil
+}
+
+// SetValid changes this Float's value and also sets it to be non-null.
+func (f *Float) SetValid(n float64) {
+	f.Float64 = n
+	f.Valid = true
+}
+
+// Ptr returns a pointer to this Float's value, or a nil pointer if this Float is null.
+func (f Float) Ptr() *float64 {
+	if !f.Valid {
+		return nil
+	}
+	return &f.Float64
+}
+
+// IsZero returns true for invalid Floats, for future omitempty support (Go 1.4?)
+// A non-null Float with a 0 value will not be considered zero.
+func (f Float) IsZero() bool {
+	return !f.Valid
+}

--- a/vendor/src/github.com/guregu/null/float_test.go
+++ b/vendor/src/github.com/guregu/null/float_test.go
@@ -1,0 +1,163 @@
+package null
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	floatJSON     = []byte(`1.2345`)
+	nullFloatJSON = []byte(`{"Float64":1.2345,"Valid":true}`)
+)
+
+func TestFloatFrom(t *testing.T) {
+	f := FloatFrom(1.2345)
+	assertFloat(t, f, "FloatFrom()")
+
+	zero := FloatFrom(0)
+	if !zero.Valid {
+		t.Error("FloatFrom(0)", "is invalid, but should be valid")
+	}
+}
+
+func TestFloatFromPtr(t *testing.T) {
+	n := float64(1.2345)
+	iptr := &n
+	f := FloatFromPtr(iptr)
+	assertFloat(t, f, "FloatFromPtr()")
+
+	null := FloatFromPtr(nil)
+	assertNullFloat(t, null, "FloatFromPtr(nil)")
+}
+
+func TestUnmarshalFloat(t *testing.T) {
+	var f Float
+	err := json.Unmarshal(floatJSON, &f)
+	maybePanic(err)
+	assertFloat(t, f, "float json")
+
+	var nf Float
+	err = json.Unmarshal(nullFloatJSON, &nf)
+	maybePanic(err)
+	assertFloat(t, nf, "sq.NullFloat64 json")
+
+	var null Float
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullFloat(t, null, "null json")
+
+	var badType Float
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullFloat(t, badType, "wrong type json")
+}
+
+func TestTextUnmarshalFloat(t *testing.T) {
+	var f Float
+	err := f.UnmarshalText([]byte("1.2345"))
+	maybePanic(err)
+	assertFloat(t, f, "UnmarshalText() float")
+
+	var blank Float
+	err = blank.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullFloat(t, blank, "UnmarshalText() empty float")
+
+	var null Float
+	err = null.UnmarshalText([]byte("null"))
+	maybePanic(err)
+	assertNullFloat(t, null, `UnmarshalText() "null"`)
+}
+
+func TestMarshalFloat(t *testing.T) {
+	f := FloatFrom(1.2345)
+	data, err := json.Marshal(f)
+	maybePanic(err)
+	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
+
+	// invalid values should be encoded as null
+	null := NewFloat(0, false)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "null", "null json marshal")
+}
+
+func TestMarshalFloatText(t *testing.T) {
+	f := FloatFrom(1.2345)
+	data, err := f.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
+
+	// invalid values should be encoded as null
+	null := NewFloat(0, false)
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "", "null text marshal")
+}
+
+func TestFloatPointer(t *testing.T) {
+	f := FloatFrom(1.2345)
+	ptr := f.Ptr()
+	if *ptr != 1.2345 {
+		t.Errorf("bad %s float: %#v ≠ %v\n", "pointer", ptr, 1.2345)
+	}
+
+	null := NewFloat(0, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s float: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestFloatIsZero(t *testing.T) {
+	f := FloatFrom(1.2345)
+	if f.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := NewFloat(0, false)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	zero := NewFloat(0, true)
+	if zero.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+}
+
+func TestFloatSetValid(t *testing.T) {
+	change := NewFloat(0, false)
+	assertNullFloat(t, change, "SetValid()")
+	change.SetValid(1.2345)
+	assertFloat(t, change, "SetValid()")
+}
+
+func TestFloatScan(t *testing.T) {
+	var f Float
+	err := f.Scan(1.2345)
+	maybePanic(err)
+	assertFloat(t, f, "scanned float")
+
+	var null Float
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullFloat(t, null, "scanned null")
+}
+
+func assertFloat(t *testing.T, f Float, from string) {
+	if f.Float64 != 1.2345 {
+		t.Errorf("bad %s float: %f ≠ %f\n", from, f.Float64, 1.2345)
+	}
+	if !f.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullFloat(t *testing.T, f Float, from string) {
+	if f.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}

--- a/vendor/src/github.com/guregu/null/int.go
+++ b/vendor/src/github.com/guregu/null/int.go
@@ -1,0 +1,116 @@
+package null
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// Int is an nullable int64.
+// It does not consider zero values to be null.
+// It will decode to null, not zero, if null.
+type Int struct {
+	sql.NullInt64
+}
+
+// NewInt creates a new Int
+func NewInt(i int64, valid bool) Int {
+	return Int{
+		NullInt64: sql.NullInt64{
+			Int64: i,
+			Valid: valid,
+		},
+	}
+}
+
+// IntFrom creates a new Int that will always be valid.
+func IntFrom(i int64) Int {
+	return NewInt(i, true)
+}
+
+// IntFromPtr creates a new Int that be null if i is nil.
+func IntFromPtr(i *int64) Int {
+	if i == nil {
+		return NewInt(0, false)
+	}
+	return NewInt(*i, true)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports number and null input.
+// 0 will not be considered a null Int.
+// It also supports unmarshalling a sql.NullInt64.
+func (i *Int) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch v.(type) {
+	case float64:
+		// Unmarshal again, directly to int64, to avoid intermediate float64
+		err = json.Unmarshal(data, &i.Int64)
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &i.NullInt64)
+	case nil:
+		i.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.Int", reflect.TypeOf(v).Name())
+	}
+	i.Valid = err == nil
+	return err
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null Int if the input is a blank or not an integer.
+// It will return an error if the input is not an integer, blank, or "null".
+func (i *Int) UnmarshalText(text []byte) error {
+	str := string(text)
+	if str == "" || str == "null" {
+		i.Valid = false
+		return nil
+	}
+	var err error
+	i.Int64, err = strconv.ParseInt(string(text), 10, 64)
+	i.Valid = err == nil
+	return err
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this Int is null.
+func (i Int) MarshalJSON() ([]byte, error) {
+	if !i.Valid {
+		return []byte("null"), nil
+	}
+	return []byte(strconv.FormatInt(i.Int64, 10)), nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a blank string if this Int is null.
+func (i Int) MarshalText() ([]byte, error) {
+	if !i.Valid {
+		return []byte{}, nil
+	}
+	return []byte(strconv.FormatInt(i.Int64, 10)), nil
+}
+
+// SetValid changes this Int's value and also sets it to be non-null.
+func (i *Int) SetValid(n int64) {
+	i.Int64 = n
+	i.Valid = true
+}
+
+// Ptr returns a pointer to this Int's value, or a nil pointer if this Int is null.
+func (i Int) Ptr() *int64 {
+	if !i.Valid {
+		return nil
+	}
+	return &i.Int64
+}
+
+// IsZero returns true for invalid Ints, for future omitempty support (Go 1.4?)
+// A non-null Int with a 0 value will not be considered zero.
+func (i Int) IsZero() bool {
+	return !i.Valid
+}

--- a/vendor/src/github.com/guregu/null/int_test.go
+++ b/vendor/src/github.com/guregu/null/int_test.go
@@ -1,0 +1,189 @@
+package null
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+	"testing"
+)
+
+var (
+	intJSON     = []byte(`12345`)
+	nullIntJSON = []byte(`{"Int64":12345,"Valid":true}`)
+)
+
+func TestIntFrom(t *testing.T) {
+	i := IntFrom(12345)
+	assertInt(t, i, "IntFrom()")
+
+	zero := IntFrom(0)
+	if !zero.Valid {
+		t.Error("IntFrom(0)", "is invalid, but should be valid")
+	}
+}
+
+func TestIntFromPtr(t *testing.T) {
+	n := int64(12345)
+	iptr := &n
+	i := IntFromPtr(iptr)
+	assertInt(t, i, "IntFromPtr()")
+
+	null := IntFromPtr(nil)
+	assertNullInt(t, null, "IntFromPtr(nil)")
+}
+
+func TestUnmarshalInt(t *testing.T) {
+	var i Int
+	err := json.Unmarshal(intJSON, &i)
+	maybePanic(err)
+	assertInt(t, i, "int json")
+
+	var ni Int
+	err = json.Unmarshal(nullIntJSON, &ni)
+	maybePanic(err)
+	assertInt(t, ni, "sq.NullInt64 json")
+
+	var null Int
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullInt(t, null, "null json")
+
+	var badType Int
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullInt(t, badType, "wrong type json")
+}
+
+func TestUnmarshalNonIntegerNumber(t *testing.T) {
+	var i Int
+	err := json.Unmarshal(floatJSON, &i)
+	if err == nil {
+		panic("err should be present; non-integer number coerced to int")
+	}
+}
+
+func TestUnmarshalInt64Overflow(t *testing.T) {
+	int64Overflow := uint64(math.MaxInt64)
+
+	// Max int64 should decode successfully
+	var i Int
+	err := json.Unmarshal([]byte(strconv.FormatUint(int64Overflow, 10)), &i)
+	maybePanic(err)
+
+	// Attempt to overflow
+	int64Overflow++
+	err = json.Unmarshal([]byte(strconv.FormatUint(int64Overflow, 10)), &i)
+	if err == nil {
+		panic("err should be present; decoded value overflows int64")
+	}
+}
+
+func TestTextUnmarshalInt(t *testing.T) {
+	var i Int
+	err := i.UnmarshalText([]byte("12345"))
+	maybePanic(err)
+	assertInt(t, i, "UnmarshalText() int")
+
+	var blank Int
+	err = blank.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullInt(t, blank, "UnmarshalText() empty int")
+
+	var null Int
+	err = null.UnmarshalText([]byte("null"))
+	maybePanic(err)
+	assertNullInt(t, null, `UnmarshalText() "null"`)
+}
+
+func TestMarshalInt(t *testing.T) {
+	i := IntFrom(12345)
+	data, err := json.Marshal(i)
+	maybePanic(err)
+	assertJSONEquals(t, data, "12345", "non-empty json marshal")
+
+	// invalid values should be encoded as null
+	null := NewInt(0, false)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "null", "null json marshal")
+}
+
+func TestMarshalIntText(t *testing.T) {
+	i := IntFrom(12345)
+	data, err := i.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "12345", "non-empty text marshal")
+
+	// invalid values should be encoded as null
+	null := NewInt(0, false)
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "", "null text marshal")
+}
+
+func TestIntPointer(t *testing.T) {
+	i := IntFrom(12345)
+	ptr := i.Ptr()
+	if *ptr != 12345 {
+		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 12345)
+	}
+
+	null := NewInt(0, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestIntIsZero(t *testing.T) {
+	i := IntFrom(12345)
+	if i.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := NewInt(0, false)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	zero := NewInt(0, true)
+	if zero.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+}
+
+func TestIntSetValid(t *testing.T) {
+	change := NewInt(0, false)
+	assertNullInt(t, change, "SetValid()")
+	change.SetValid(12345)
+	assertInt(t, change, "SetValid()")
+}
+
+func TestIntScan(t *testing.T) {
+	var i Int
+	err := i.Scan(12345)
+	maybePanic(err)
+	assertInt(t, i, "scanned int")
+
+	var null Int
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullInt(t, null, "scanned null")
+}
+
+func assertInt(t *testing.T, i Int, from string) {
+	if i.Int64 != 12345 {
+		t.Errorf("bad %s int: %d ≠ %d\n", from, i.Int64, 12345)
+	}
+	if !i.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullInt(t *testing.T, i Int, from string) {
+	if i.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}

--- a/vendor/src/github.com/guregu/null/string.go
+++ b/vendor/src/github.com/guregu/null/string.go
@@ -1,0 +1,99 @@
+// Package null contains types that consider zero input and null input as separate values.
+// Types in this package will always encode to their null value if null.
+// Use the zero subpackage if you want empty and null to be treated the same.
+package null
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// String is a nullable string. It supports SQL and JSON serialization.
+// It will marshal to null if null. Blank string input will be considered null.
+type String struct {
+	sql.NullString
+}
+
+// StringFrom creates a new String that will never be blank.
+func StringFrom(s string) String {
+	return NewString(s, true)
+}
+
+// StringFromPtr creates a new String that be null if s is nil.
+func StringFromPtr(s *string) String {
+	if s == nil {
+		return NewString("", false)
+	}
+	return NewString(*s, true)
+}
+
+// NewString creates a new String
+func NewString(s string, valid bool) String {
+	return String{
+		NullString: sql.NullString{
+			String: s,
+			Valid:  valid,
+		},
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports string and null input. Blank string input produces a null String.
+// It also supports unmarshalling a sql.NullString.
+func (s *String) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch x := v.(type) {
+	case string:
+		s.String = x
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &s.NullString)
+	case nil:
+		s.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.String", reflect.TypeOf(v).Name())
+	}
+	s.Valid = (err == nil) && (s.String != "")
+	return err
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this String is null.
+func (s String) MarshalJSON() ([]byte, error) {
+	if !s.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(s.String)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null String if the input is a blank string.
+func (s *String) UnmarshalText(text []byte) error {
+	s.String = string(text)
+	s.Valid = s.String != ""
+	return nil
+}
+
+// SetValid changes this String's value and also sets it to be non-null.
+func (s *String) SetValid(v string) {
+	s.String = v
+	s.Valid = true
+}
+
+// Ptr returns a pointer to this String's value, or a nil pointer if this String is null.
+func (s String) Ptr() *string {
+	if !s.Valid {
+		return nil
+	}
+	return &s.String
+}
+
+// IsZero returns true for null or empty strings, for future omitempty support. (Go 1.4?)
+// Will return false s if blank but non-null.
+func (s String) IsZero() bool {
+	return !s.Valid
+}

--- a/vendor/src/github.com/guregu/null/string_test.go
+++ b/vendor/src/github.com/guregu/null/string_test.go
@@ -1,0 +1,186 @@
+package null
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	stringJSON      = []byte(`"test"`)
+	blankStringJSON = []byte(`""`)
+	nullStringJSON  = []byte(`{"String":"test","Valid":true}`)
+	nullJSON        = []byte(`null`)
+)
+
+type stringInStruct struct {
+	Test String `json:"test,omitempty"`
+}
+
+func TestStringFrom(t *testing.T) {
+	str := StringFrom("test")
+	assertStr(t, str, "StringFrom() string")
+
+	zero := StringFrom("")
+	if !zero.Valid {
+		t.Error("StringFrom(0)", "is invalid, but should be valid")
+	}
+}
+
+func TestStringFromPtr(t *testing.T) {
+	s := "test"
+	sptr := &s
+	str := StringFromPtr(sptr)
+	assertStr(t, str, "StringFromPtr() string")
+
+	null := StringFromPtr(nil)
+	assertNullStr(t, null, "StringFromPtr(nil)")
+}
+
+func TestUnmarshalString(t *testing.T) {
+	var str String
+	err := json.Unmarshal(stringJSON, &str)
+	maybePanic(err)
+	assertStr(t, str, "string json")
+
+	var ns String
+	err = json.Unmarshal(nullStringJSON, &ns)
+	maybePanic(err)
+	assertStr(t, ns, "sql.NullString json")
+
+	var blank String
+	err = json.Unmarshal(blankStringJSON, &blank)
+	maybePanic(err)
+	assertNullStr(t, blank, "blank string json")
+
+	var null String
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullStr(t, null, "null json")
+
+	var badType String
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullStr(t, badType, "wrong type json")
+}
+
+func TestTextUnmarshalString(t *testing.T) {
+	var str String
+	err := str.UnmarshalText([]byte("test"))
+	maybePanic(err)
+	assertStr(t, str, "UnmarshalText() string")
+
+	var null String
+	err = null.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullStr(t, null, "UnmarshalText() empty string")
+}
+
+func TestMarshalString(t *testing.T) {
+	str := StringFrom("test")
+	data, err := json.Marshal(str)
+	maybePanic(err)
+	assertJSONEquals(t, data, `"test"`, "non-empty json marshal")
+
+	// empty values should be encoded as an empty string
+	zero := StringFrom("")
+	data, err = json.Marshal(zero)
+	maybePanic(err)
+	assertJSONEquals(t, data, `""`, "empty json marshal")
+
+	null := StringFromPtr(nil)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, `null`, "null json marshal")
+}
+
+// Tests omitempty... broken until Go 1.4
+// func TestMarshalStringInStruct(t *testing.T) {
+// 	obj := stringInStruct{Test: StringFrom("")}
+// 	data, err := json.Marshal(obj)
+// 	maybePanic(err)
+// 	assertJSONEquals(t, data, `{}`, "null string in struct")
+// }
+
+func TestStringPointer(t *testing.T) {
+	str := StringFrom("test")
+	ptr := str.Ptr()
+	if *ptr != "test" {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "pointer", ptr, "test")
+	}
+
+	null := NewString("", false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestStringIsZero(t *testing.T) {
+	str := StringFrom("test")
+	if str.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	blank := StringFrom("")
+	if blank.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	empty := NewString("", true)
+	if empty.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := StringFromPtr(nil)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestStringSetValid(t *testing.T) {
+	change := NewString("", false)
+	assertNullStr(t, change, "SetValid()")
+	change.SetValid("test")
+	assertStr(t, change, "SetValid()")
+}
+
+func TestStringScan(t *testing.T) {
+	var str String
+	err := str.Scan("test")
+	maybePanic(err)
+	assertStr(t, str, "scanned string")
+
+	var null String
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullStr(t, null, "scanned null")
+}
+
+func maybePanic(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func assertStr(t *testing.T, s String, from string) {
+	if s.String != "test" {
+		t.Errorf("bad %s string: %s ≠ %s\n", from, s.String, "test")
+	}
+	if !s.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullStr(t *testing.T, s String, from string) {
+	if s.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertJSONEquals(t *testing.T, data []byte, cmp string, from string) {
+	if string(data) != cmp {
+		t.Errorf("bad %s data: %s ≠ %s\n", from, data, cmp)
+	}
+}

--- a/vendor/src/github.com/guregu/null/zero/bool.go
+++ b/vendor/src/github.com/guregu/null/zero/bool.go
@@ -1,0 +1,118 @@
+package zero
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Bool is a nullable bool. False input is considered null.
+// Considered null to SQL unmarshaled from a false value.
+type Bool struct {
+	sql.NullBool
+}
+
+// NewBool creates a new Bool
+func NewBool(b bool, valid bool) Bool {
+	return Bool{
+		NullBool: sql.NullBool{
+			Bool:  b,
+			Valid: valid,
+		},
+	}
+}
+
+// BoolFrom creates a new Bool that will be null if false.
+func BoolFrom(b bool) Bool {
+	return NewBool(b, b)
+}
+
+// BoolFromPtr creates a new Bool that be null if b is nil.
+func BoolFromPtr(b *bool) Bool {
+	if b == nil {
+		return NewBool(false, false)
+	}
+	return NewBool(*b, true)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// "false" will be considered a null Bool.
+// It also supports unmarshalling a sql.NullBool.
+func (b *Bool) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch x := v.(type) {
+	case bool:
+		b.Bool = x
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &b.NullBool)
+	case nil:
+		b.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type zero.Bool", reflect.TypeOf(v).Name())
+	}
+	b.Valid = (err == nil) && b.Bool
+	return err
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null Bool if the input is a false or not a bool.
+// It will return an error if the input is not a float, blank, or "null".
+func (b *Bool) UnmarshalText(text []byte) error {
+	str := string(text)
+	switch str {
+	case "", "null":
+		b.Valid = false
+		return nil
+	case "true":
+		b.Bool = true
+	case "false":
+		b.Bool = false
+	default:
+		b.Valid = false
+		return errors.New("invalid input:" + str)
+	}
+	b.Valid = b.Bool
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this Bool is null.
+func (b Bool) MarshalJSON() ([]byte, error) {
+	if !b.Valid || !b.Bool {
+		return []byte("false"), nil
+	}
+	return []byte("true"), nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a zero if this Bool is null.
+func (b Bool) MarshalText() ([]byte, error) {
+	if !b.Valid || !b.Bool {
+		return []byte("false"), nil
+	}
+	return []byte("true"), nil
+}
+
+// SetValid changes this Bool's value and also sets it to be non-null.
+func (b *Bool) SetValid(v bool) {
+	b.Bool = v
+	b.Valid = true
+}
+
+// Ptr returns a poBooler to this Bool's value, or a nil poBooler if this Bool is null.
+func (b Bool) Ptr() *bool {
+	if !b.Valid {
+		return nil
+	}
+	return &b.Bool
+}
+
+// IsZero returns true for null or zero Bools, for future omitempty support (Go 1.4?)
+func (b Bool) IsZero() bool {
+	return !b.Valid || !b.Bool
+}

--- a/vendor/src/github.com/guregu/null/zero/bool_test.go
+++ b/vendor/src/github.com/guregu/null/zero/bool_test.go
@@ -1,0 +1,182 @@
+package zero
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	boolJSON     = []byte(`true`)
+	falseJSON    = []byte(`false`)
+	nullBoolJSON = []byte(`{"Bool":true,"Valid":true}`)
+	invalidJSON  = []byte(`:)`)
+)
+
+func TestBoolFrom(t *testing.T) {
+	b := BoolFrom(true)
+	assertBool(t, b, "BoolFrom()")
+
+	zero := BoolFrom(false)
+	if zero.Valid {
+		t.Error("BoolFrom(false)", "is valid, but should be invalid")
+	}
+}
+
+func TestBoolFromPtr(t *testing.T) {
+	v := true
+	bptr := &v
+	b := BoolFromPtr(bptr)
+	assertBool(t, b, "BoolFromPtr()")
+
+	null := BoolFromPtr(nil)
+	assertNullBool(t, null, "BoolFromPtr(nil)")
+}
+
+func TestUnmarshalBool(t *testing.T) {
+	var b Bool
+	err := json.Unmarshal(boolJSON, &b)
+	maybePanic(err)
+	assertBool(t, b, "float json")
+
+	var nb Bool
+	err = json.Unmarshal(nullBoolJSON, &nb)
+	maybePanic(err)
+	assertBool(t, nb, "sql.NullBool json")
+
+	var zero Bool
+	err = json.Unmarshal(falseJSON, &zero)
+	maybePanic(err)
+	assertNullBool(t, zero, "zero json")
+
+	var null Bool
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullBool(t, null, "null json")
+
+	var invalid Bool
+	err = invalid.UnmarshalText(invalidJSON)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullBool(t, invalid, "invalid json")
+
+	var badType Bool
+	err = json.Unmarshal(intJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullBool(t, badType, "wrong type json")
+}
+
+func TestTextUnmarshalBool(t *testing.T) {
+	var b Bool
+	err := b.UnmarshalText(boolJSON)
+	maybePanic(err)
+	assertBool(t, b, "UnmarshalText() bool")
+
+	var zero Bool
+	err = zero.UnmarshalText(falseJSON)
+	maybePanic(err)
+	assertNullBool(t, zero, "UnmarshalText() zero bool")
+
+	var blank Bool
+	err = blank.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullBool(t, blank, "UnmarshalText() empty bool")
+
+	var null Bool
+	err = null.UnmarshalText(nullJSON)
+	maybePanic(err)
+	assertNullBool(t, null, `UnmarshalText() "null"`)
+}
+
+func TestMarshalBool(t *testing.T) {
+	b := BoolFrom(true)
+	data, err := json.Marshal(b)
+	maybePanic(err)
+	assertJSONEquals(t, data, "true", "non-empty json marshal")
+
+	// invalid values should be encoded as false
+	null := NewBool(false, false)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "false", "null json marshal")
+}
+
+func TestMarshalBoolText(t *testing.T) {
+	b := BoolFrom(true)
+	data, err := b.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "true", "non-empty text marshal")
+
+	// invalid values should be encoded as zero
+	null := NewBool(false, false)
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "false", "null text marshal")
+}
+
+func TestBoolPointer(t *testing.T) {
+	b := BoolFrom(true)
+	ptr := b.Ptr()
+	if *ptr != true {
+		t.Errorf("bad %s bool: %#v ≠ %v\n", "pointer", ptr, true)
+	}
+
+	null := NewBool(false, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s bool: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestBoolIsZero(t *testing.T) {
+	b := BoolFrom(true)
+	if b.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := NewBool(false, false)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	zero := NewBool(false, true)
+	if !zero.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestBoolSetValid(t *testing.T) {
+	change := NewBool(false, false)
+	assertNullBool(t, change, "SetValid()")
+	change.SetValid(true)
+	assertBool(t, change, "SetValid()")
+}
+
+func TestBoolScan(t *testing.T) {
+	var b Bool
+	err := b.Scan(true)
+	maybePanic(err)
+	assertBool(t, b, "scanned bool")
+
+	var null Bool
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullBool(t, null, "scanned null")
+}
+
+func assertBool(t *testing.T, b Bool, from string) {
+	if b.Bool != true {
+		t.Errorf("bad %s bool: %d ≠ %v\n", from, b.Bool, true)
+	}
+	if !b.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullBool(t *testing.T, b Bool, from string) {
+	if b.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}

--- a/vendor/src/github.com/guregu/null/zero/float.go
+++ b/vendor/src/github.com/guregu/null/zero/float.go
@@ -1,0 +1,116 @@
+package zero
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// Float is a nullable float64. Zero input will be considered null.
+// JSON marshals to zero if null.
+// Considered null to SQL if zero.
+type Float struct {
+	sql.NullFloat64
+}
+
+// NewFloat creates a new Float
+func NewFloat(f float64, valid bool) Float {
+	return Float{
+		NullFloat64: sql.NullFloat64{
+			Float64: f,
+			Valid:   valid,
+		},
+	}
+}
+
+// FloatFrom creates a new Float that will be null if zero.
+func FloatFrom(f float64) Float {
+	return NewFloat(f, f != 0)
+}
+
+// FloatFromPtr creates a new Float that be null if f is nil.
+func FloatFromPtr(f *float64) Float {
+	if f == nil {
+		return NewFloat(0, false)
+	}
+	return NewFloat(*f, true)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports number and null input.
+// 0 will be considered a null Float.
+// It also supports unmarshalling a sql.NullFloat64.
+func (f *Float) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch x := v.(type) {
+	case float64:
+		f.Float64 = x
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &f.NullFloat64)
+	case nil:
+		f.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type zero.Float", reflect.TypeOf(v).Name())
+	}
+	f.Valid = (err == nil) && (f.Float64 != 0)
+	return err
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null Float if the input is a blank, zero, or not a float.
+// It will return an error if the input is not a float, blank, or "null".
+func (f *Float) UnmarshalText(text []byte) error {
+	str := string(text)
+	if str == "" || str == "null" {
+		f.Valid = false
+		return nil
+	}
+	var err error
+	f.Float64, err = strconv.ParseFloat(string(text), 64)
+	f.Valid = (err == nil) && (f.Float64 != 0)
+	return err
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this Float is null.
+func (f Float) MarshalJSON() ([]byte, error) {
+	n := f.Float64
+	if !f.Valid {
+		n = 0
+	}
+	return []byte(strconv.FormatFloat(n, 'f', -1, 64)), nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a zero if this Float is null.
+func (f Float) MarshalText() ([]byte, error) {
+	n := f.Float64
+	if !f.Valid {
+		n = 0
+	}
+	return []byte(strconv.FormatFloat(n, 'f', -1, 64)), nil
+}
+
+// SetValid changes this Float's value and also sets it to be non-null.
+func (f *Float) SetValid(v float64) {
+	f.Float64 = v
+	f.Valid = true
+}
+
+// Ptr returns a poFloater to this Float's value, or a nil poFloater if this Float is null.
+func (f Float) Ptr() *float64 {
+	if !f.Valid {
+		return nil
+	}
+	return &f.Float64
+}
+
+// IsZero returns true for null or zero Floats, for future omitempty support (Go 1.4?)
+func (f Float) IsZero() bool {
+	return !f.Valid || f.Float64 == 0
+}

--- a/vendor/src/github.com/guregu/null/zero/float_test.go
+++ b/vendor/src/github.com/guregu/null/zero/float_test.go
@@ -1,0 +1,173 @@
+package zero
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	floatJSON     = []byte(`1.2345`)
+	nullFloatJSON = []byte(`{"Float64":1.2345,"Valid":true}`)
+)
+
+func TestFloatFrom(t *testing.T) {
+	f := FloatFrom(1.2345)
+	assertFloat(t, f, "FloatFrom()")
+
+	zero := FloatFrom(0)
+	if zero.Valid {
+		t.Error("FloatFrom(0)", "is valid, but should be invalid")
+	}
+}
+
+func TestFloatFromPtr(t *testing.T) {
+	n := float64(1.2345)
+	iptr := &n
+	f := FloatFromPtr(iptr)
+	assertFloat(t, f, "FloatFromPtr()")
+
+	null := FloatFromPtr(nil)
+	assertNullFloat(t, null, "FloatFromPtr(nil)")
+}
+
+func TestUnmarshalFloat(t *testing.T) {
+	var f Float
+	err := json.Unmarshal(floatJSON, &f)
+	maybePanic(err)
+	assertFloat(t, f, "float json")
+
+	var nf Float
+	err = json.Unmarshal(nullFloatJSON, &nf)
+	maybePanic(err)
+	assertFloat(t, nf, "sql.NullFloat64 json")
+
+	var zero Float
+	err = json.Unmarshal(zeroJSON, &zero)
+	maybePanic(err)
+	assertNullFloat(t, zero, "zero json")
+
+	var null Float
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullFloat(t, null, "null json")
+
+	var badType Float
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullFloat(t, badType, "wrong type json")
+}
+
+func TestTextUnmarshalFloat(t *testing.T) {
+	var f Float
+	err := f.UnmarshalText([]byte("1.2345"))
+	maybePanic(err)
+	assertFloat(t, f, "UnmarshalText() float")
+
+	var zero Float
+	err = zero.UnmarshalText([]byte("0"))
+	maybePanic(err)
+	assertNullFloat(t, zero, "UnmarshalText() zero float")
+
+	var blank Float
+	err = blank.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullFloat(t, blank, "UnmarshalText() empty float")
+
+	var null Float
+	err = null.UnmarshalText([]byte("null"))
+	maybePanic(err)
+	assertNullFloat(t, null, `UnmarshalText() "null"`)
+}
+
+func TestMarshalFloat(t *testing.T) {
+	f := FloatFrom(1.2345)
+	data, err := json.Marshal(f)
+	maybePanic(err)
+	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
+
+	// invalid values should be encoded as 0
+	null := NewFloat(0, false)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "0", "null json marshal")
+}
+
+func TestMarshalFloatText(t *testing.T) {
+	f := FloatFrom(1.2345)
+	data, err := f.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
+
+	// invalid values should be encoded as zero
+	null := NewFloat(0, false)
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "0", "null text marshal")
+}
+
+func TestFloatPointer(t *testing.T) {
+	f := FloatFrom(1.2345)
+	ptr := f.Ptr()
+	if *ptr != 1.2345 {
+		t.Errorf("bad %s Float: %#v ≠ %v\n", "pointer", ptr, 1.2345)
+	}
+
+	null := NewFloat(0, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s Float: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestFloatIsZero(t *testing.T) {
+	f := FloatFrom(1.2345)
+	if f.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := NewFloat(0, false)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	zero := NewFloat(0, true)
+	if !zero.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestFloatSetValid(t *testing.T) {
+	change := NewFloat(0, false)
+	assertNullFloat(t, change, "SetValid()")
+	change.SetValid(1.2345)
+	assertFloat(t, change, "SetValid()")
+}
+
+func TestFloatScan(t *testing.T) {
+	var f Float
+	err := f.Scan(1.2345)
+	maybePanic(err)
+	assertFloat(t, f, "scanned float")
+
+	var null Float
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullFloat(t, null, "scanned null")
+}
+
+func assertFloat(t *testing.T, f Float, from string) {
+	if f.Float64 != 1.2345 {
+		t.Errorf("bad %s float: %f ≠ %f\n", from, f.Float64, 1.2345)
+	}
+	if !f.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullFloat(t *testing.T, f Float, from string) {
+	if f.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}

--- a/vendor/src/github.com/guregu/null/zero/int.go
+++ b/vendor/src/github.com/guregu/null/zero/int.go
@@ -1,0 +1,118 @@
+package zero
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// Int is a nullable int64.
+// JSON marshals to zero if null.
+// Considered null to SQL if zero.
+type Int struct {
+	sql.NullInt64
+}
+
+// NewInt creates a new Int
+func NewInt(i int64, valid bool) Int {
+	return Int{
+		NullInt64: sql.NullInt64{
+			Int64: i,
+			Valid: valid,
+		},
+	}
+}
+
+// IntFrom creates a new Int that will be null if zero.
+func IntFrom(i int64) Int {
+	return NewInt(i, i != 0)
+}
+
+// IntFromPtr creates a new Int that be null if i is nil.
+func IntFromPtr(i *int64) Int {
+	if i == nil {
+		return NewInt(0, false)
+	}
+	n := NewInt(*i, true)
+	return n
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports number and null input.
+// 0 will be considered a null Int.
+// It also supports unmarshalling a sql.NullInt64.
+func (i *Int) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch v.(type) {
+	case float64:
+		// Unmarshal again, directly to int64, to avoid intermediate float64
+		err = json.Unmarshal(data, &i.Int64)
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &i.NullInt64)
+	case nil:
+		i.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type zero.Int", reflect.TypeOf(v).Name())
+	}
+	i.Valid = (err == nil) && (i.Int64 != 0)
+	return err
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null Int if the input is a blank, zero, or not an integer.
+// It will return an error if the input is not an integer, blank, or "null".
+func (i *Int) UnmarshalText(text []byte) error {
+	str := string(text)
+	if str == "" || str == "null" {
+		i.Valid = false
+		return nil
+	}
+	var err error
+	i.Int64, err = strconv.ParseInt(string(text), 10, 64)
+	i.Valid = (err == nil) && (i.Int64 != 0)
+	return err
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode 0 if this Int is null.
+func (i Int) MarshalJSON() ([]byte, error) {
+	n := i.Int64
+	if !i.Valid {
+		n = 0
+	}
+	return []byte(strconv.FormatInt(n, 10)), nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a zero if this Int is null.
+func (i Int) MarshalText() ([]byte, error) {
+	n := i.Int64
+	if !i.Valid {
+		n = 0
+	}
+	return []byte(strconv.FormatInt(n, 10)), nil
+}
+
+// SetValid changes this Int's value and also sets it to be non-null.
+func (i *Int) SetValid(n int64) {
+	i.Int64 = n
+	i.Valid = true
+}
+
+// Ptr returns a pointer to this Int's value, or a nil pointer if this Int is null.
+func (i Int) Ptr() *int64 {
+	if !i.Valid {
+		return nil
+	}
+	return &i.Int64
+}
+
+// IsZero returns true for null or zero Ints, for future omitempty support (Go 1.4?)
+func (i Int) IsZero() bool {
+	return !i.Valid || i.Int64 == 0
+}

--- a/vendor/src/github.com/guregu/null/zero/int_test.go
+++ b/vendor/src/github.com/guregu/null/zero/int_test.go
@@ -1,0 +1,200 @@
+package zero
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+	"testing"
+)
+
+var (
+	intJSON     = []byte(`12345`)
+	nullIntJSON = []byte(`{"Int64":12345,"Valid":true}`)
+	zeroJSON    = []byte(`0`)
+)
+
+func TestIntFrom(t *testing.T) {
+	i := IntFrom(12345)
+	assertInt(t, i, "IntFrom()")
+
+	zero := IntFrom(0)
+	if zero.Valid {
+		t.Error("IntFrom(0)", "is valid, but should be invalid")
+	}
+}
+
+func TestIntFromPtr(t *testing.T) {
+	n := int64(12345)
+	iptr := &n
+	i := IntFromPtr(iptr)
+	assertInt(t, i, "IntFromPtr()")
+
+	null := IntFromPtr(nil)
+	assertNullInt(t, null, "IntFromPtr(nil)")
+}
+
+func TestUnmarshalInt(t *testing.T) {
+	var i Int
+	err := json.Unmarshal(intJSON, &i)
+	maybePanic(err)
+	assertInt(t, i, "int json")
+
+	var ni Int
+	err = json.Unmarshal(nullIntJSON, &ni)
+	maybePanic(err)
+	assertInt(t, ni, "sql.NullInt64 json")
+
+	var zero Int
+	err = json.Unmarshal(zeroJSON, &zero)
+	maybePanic(err)
+	assertNullInt(t, zero, "zero json")
+
+	var null Int
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullInt(t, null, "null json")
+
+	var badType Int
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullInt(t, badType, "wrong type json")
+}
+
+func TestUnmarshalNonIntegerNumber(t *testing.T) {
+	var i Int
+	err := json.Unmarshal(floatJSON, &i)
+	if err == nil {
+		panic("err should be present; non-integer number coerced to int")
+	}
+}
+
+func TestUnmarshalInt64Overflow(t *testing.T) {
+	int64Overflow := uint64(math.MaxInt64)
+
+	// Max int64 should decode successfully
+	var i Int
+	err := json.Unmarshal([]byte(strconv.FormatUint(int64Overflow, 10)), &i)
+	maybePanic(err)
+
+	// Attempt to overflow
+	int64Overflow++
+	err = json.Unmarshal([]byte(strconv.FormatUint(int64Overflow, 10)), &i)
+	if err == nil {
+		panic("err should be present; decoded value overflows int64")
+	}
+}
+
+func TestTextUnmarshalInt(t *testing.T) {
+	var i Int
+	err := i.UnmarshalText([]byte("12345"))
+	maybePanic(err)
+	assertInt(t, i, "UnmarshalText() int")
+
+	var zero Int
+	err = zero.UnmarshalText([]byte("0"))
+	maybePanic(err)
+	assertNullInt(t, zero, "UnmarshalText() zero int")
+
+	var blank Int
+	err = blank.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullInt(t, blank, "UnmarshalText() empty int")
+
+	var null Int
+	err = null.UnmarshalText([]byte("null"))
+	maybePanic(err)
+	assertNullInt(t, null, `UnmarshalText() "null"`)
+}
+
+func TestMarshalInt(t *testing.T) {
+	i := IntFrom(12345)
+	data, err := json.Marshal(i)
+	maybePanic(err)
+	assertJSONEquals(t, data, "12345", "non-empty json marshal")
+
+	// invalid values should be encoded as 0
+	null := NewInt(0, false)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "0", "null json marshal")
+}
+
+func TestMarshalIntText(t *testing.T) {
+	i := IntFrom(12345)
+	data, err := i.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "12345", "non-empty text marshal")
+
+	// invalid values should be encoded as zero
+	null := NewInt(0, false)
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "0", "null text marshal")
+}
+
+func TestIntPointer(t *testing.T) {
+	i := IntFrom(12345)
+	ptr := i.Ptr()
+	if *ptr != 12345 {
+		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 12345)
+	}
+
+	null := NewInt(0, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestIntIsZero(t *testing.T) {
+	i := IntFrom(12345)
+	if i.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := NewInt(0, false)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	zero := NewInt(0, true)
+	if !zero.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestIntScan(t *testing.T) {
+	var i Int
+	err := i.Scan(12345)
+	maybePanic(err)
+	assertInt(t, i, "scanned int")
+
+	var null Int
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullInt(t, null, "scanned null")
+}
+
+func TestIntSetValid(t *testing.T) {
+	change := NewInt(0, false)
+	assertNullInt(t, change, "SetValid()")
+	change.SetValid(12345)
+	assertInt(t, change, "SetValid()")
+}
+
+func assertInt(t *testing.T, i Int, from string) {
+	if i.Int64 != 12345 {
+		t.Errorf("bad %s int: %d ≠ %d\n", from, i.Int64, 12345)
+	}
+	if !i.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullInt(t *testing.T, i Int, from string) {
+	if i.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}

--- a/vendor/src/github.com/guregu/null/zero/string.go
+++ b/vendor/src/github.com/guregu/null/zero/string.go
@@ -1,0 +1,101 @@
+// Package zero provides a convenient way of handling null values.
+// Types in this package consider empty or zero input the same as null input.
+// Types in this package will encode to their zero value, even if null.
+// Use the null parent package if you don't want this.
+package zero
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// String is a nullable string.
+// JSON marshals to a blank string if null.
+// Considered null to SQL if zero.
+type String struct {
+	sql.NullString
+}
+
+// NewString creates a new String
+func NewString(s string, valid bool) String {
+	return String{
+		NullString: sql.NullString{
+			String: s,
+			Valid:  valid,
+		},
+	}
+}
+
+// StringFrom creates a new String that will be null if s is blank.
+func StringFrom(s string) String {
+	return NewString(s, s != "")
+}
+
+// StringFromPtr creates a new String that be null if s is nil or blank.
+// It will make s point to the String's value.
+func StringFromPtr(s *string) String {
+	if s == nil {
+		return NewString("", false)
+	}
+	return NewString(*s, *s != "")
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports string and null input. Blank string input produces a null String.
+// It also supports unmarshalling a sql.NullString.
+func (s *String) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	json.Unmarshal(data, &v)
+	switch x := v.(type) {
+	case string:
+		s.String = x
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &s.NullString)
+	case nil:
+		s.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type zero.String", reflect.TypeOf(v).Name())
+	}
+	s.Valid = (err == nil) && (s.String != "")
+	return err
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a blank string when this String is null.
+func (s String) MarshalText() ([]byte, error) {
+	if !s.Valid {
+		return []byte{}, nil
+	}
+	return []byte(s.String), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null String if the input is a blank string.
+func (s *String) UnmarshalText(text []byte) error {
+	s.String = string(text)
+	s.Valid = s.String != ""
+	return nil
+}
+
+// SetValid changes this String's value and also sets it to be non-null.
+func (s *String) SetValid(v string) {
+	s.String = v
+	s.Valid = true
+}
+
+// Ptr returns a pointer to this String's value, or a nil pointer if this String is null.
+func (s String) Ptr() *string {
+	if !s.Valid {
+		return nil
+	}
+	return &s.String
+}
+
+// IsZero returns true for null or empty strings, for future omitempty support. (Go 1.4?)
+func (s String) IsZero() bool {
+	return !s.Valid || s.String == ""
+}

--- a/vendor/src/github.com/guregu/null/zero/string_test.go
+++ b/vendor/src/github.com/guregu/null/zero/string_test.go
@@ -1,0 +1,180 @@
+package zero
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	stringJSON      = []byte(`"test"`)
+	blankStringJSON = []byte(`""`)
+	nullStringJSON  = []byte(`{"String":"test","Valid":true}`)
+	nullJSON        = []byte(`null`)
+)
+
+type stringInStruct struct {
+	Test String `json:"test,omitempty"`
+}
+
+func TestStringFrom(t *testing.T) {
+	str := StringFrom("test")
+	assertStr(t, str, "StringFrom() string")
+
+	null := StringFrom("")
+	assertNullStr(t, null, "StringFrom() empty string")
+}
+
+func TestUnmarshalString(t *testing.T) {
+	var str String
+	err := json.Unmarshal(stringJSON, &str)
+	maybePanic(err)
+	assertStr(t, str, "string json")
+
+	var ns String
+	err = json.Unmarshal(nullStringJSON, &ns)
+	maybePanic(err)
+	assertStr(t, ns, "sql.NullString json")
+
+	var blank String
+	err = json.Unmarshal(blankStringJSON, &blank)
+	maybePanic(err)
+	assertNullStr(t, blank, "blank string json")
+
+	var null String
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullStr(t, null, "null json")
+
+	var badType String
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullStr(t, badType, "wrong type json")
+}
+
+func TestTextUnmarshalString(t *testing.T) {
+	var str String
+	err := str.UnmarshalText([]byte("test"))
+	maybePanic(err)
+	assertStr(t, str, "UnmarshalText() string")
+
+	var null String
+	err = null.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullStr(t, null, "UnmarshalText() empty string")
+}
+
+func TestMarshalString(t *testing.T) {
+	str := StringFrom("test")
+	data, err := json.Marshal(str)
+	maybePanic(err)
+	assertJSONEquals(t, data, `"test"`, "non-empty json marshal")
+
+	// invalid values should be encoded as an empty string
+	null := StringFrom("")
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, `""`, "empty json marshal")
+}
+
+// Tests omitempty... broken until Go 1.4
+// func TestMarshalStringInStruct(t *testing.T) {
+// 	obj := stringInStruct{Test: StringFrom("")}
+// 	data, err := json.Marshal(obj)
+// 	maybePanic(err)
+// 	assertJSONEquals(t, data, `{}`, "null string in struct")
+// }
+
+func TestStringPointer(t *testing.T) {
+	str := StringFrom("test")
+	ptr := str.Ptr()
+	if *ptr != "test" {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "pointer", ptr, "test")
+	}
+
+	null := StringFrom("")
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestStringFromPointer(t *testing.T) {
+	test := "test"
+	testptr := &test
+	str := StringFromPtr(testptr)
+	assertStr(t, str, "StringFromPtr()")
+
+	testptr = nil
+	null := StringFromPtr(testptr)
+	assertNullStr(t, null, "StringFromPtr()")
+
+	ptr := null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestStringIsZero(t *testing.T) {
+	str := StringFrom("test")
+	if str.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := StringFrom("")
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+
+	empty := NewString("", true)
+	if !empty.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestStringScan(t *testing.T) {
+	var str String
+	err := str.Scan("test")
+	maybePanic(err)
+	assertStr(t, str, "scanned string")
+
+	var null String
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullStr(t, null, "scanned null")
+}
+
+func TestStringSetValid(t *testing.T) {
+	change := NewString("", false)
+	assertNullStr(t, change, "SetValid()")
+	change.SetValid("test")
+	assertStr(t, change, "SetValid()")
+}
+
+func maybePanic(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func assertStr(t *testing.T, s String, from string) {
+	if s.String != "test" {
+		t.Errorf("bad %s string: %s ≠ %s\n", from, s.String, "test")
+	}
+	if !s.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullStr(t *testing.T, s String, from string) {
+	if s.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertJSONEquals(t *testing.T, data []byte, cmp string, from string) {
+	if string(data) != cmp {
+		t.Errorf("bad %s data: %s ≠ %s\n", from, data, cmp)
+	}
+}


### PR DESCRIPTION
This PR adds following fields to accounts endpoint:
- `numsubentries`
- `inflation_destination`
- `home_domain` (note: even though this field can be null in stellar-core database it's set to empty string for all accounts)
- `thresholds`
- `flags` (note: would be great if go-stellar-base could export [`thresholdIndexesMap`](https://github.com/stellar/go-stellar-base/blob/1f8f9327113e37d166934b0181ca0998c780b7f8/xdr/xdr_generated.go#L489) so we can loop through the values - right now values are hardcoded).

Sample response:

``` json
{
  "_links": {
    "effects": {
      "href": "/accounts/GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP/effects/{?cursor,limit,order}",
      "templated": true
    },
    "offers": {
      "href": "/accounts/GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP/offers/{?cursor,limit,order}",
      "templated": true
    },
    "operations": {
      "href": "/accounts/GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP/operations/{?cursor,limit,order}",
      "templated": true
    },
    "self": {
      "href": "/accounts/GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP"
    },
    "transactions": {
      "href": "/accounts/GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP/transactions/{?cursor,limit,order}",
      "templated": true
    }
  },
  "id": "GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP",
  "paging_token": "79340930863104",
  "address": "GDXCFO7CDES6O7LCXZOFECIHSKOMWFWBOQ22DBRSRATHUSGDGZVL2LIP",
  "sequence": 79340930859017,
  "numsubentries": 1,
  "inflation_destination": null,
  "home_domain": "",
  "thresholds": {
    "threshold_high": 1,
    "threshold_low": 1,
    "threshold_master_weight": 1,
    "threshold_med": 2
  },
  "flags": {
    "auth_required_flag": false,
    "auth_revocable_flag": true
  },
  "balances": [
    {
      "asset_type": "native",
      "balance": "3.4991000"
    }
  ],
  "signers": [
    {
      "address": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
      "weight": 1
    }
  ]
}
```

Close #83 
