### PR TITLE
Trades Endpoints

### DIFF
--- a/src/github.com/stellar/horizon/actions/helpers.go
+++ b/src/github.com/stellar/horizon/actions/helpers.go
@@ -1,11 +1,13 @@
 package actions
 
 import (
+	"net/http"
 	"strconv"
 
+	"github.com/stellar/go-stellar-base/xdr"
 	"github.com/stellar/horizon/assets"
 	"github.com/stellar/horizon/db"
-	"github.com/stellar/go-stellar-base/xdr"
+	"github.com/stellar/horizon/render/problem"
 )
 
 const (
@@ -16,6 +18,17 @@ const (
 	// ParamLimit is a query string param name
 	ParamLimit = "limit"
 )
+
+// OrderBookParams is a helper struct that encapsulates the specification for
+// an order book
+type OrderBookParams struct {
+	SellingType   xdr.AssetType
+	SellingIssuer string
+	SellingCode   string
+	BuyingType    xdr.AssetType
+	BuyingIssuer  string
+	BuyingCode    string
+}
 
 // GetString retrieves a string from either the URLParams, form or query string.
 // This method uses the priority (URLParams, Form, Query).
@@ -141,6 +154,62 @@ func (base *Base) GetAssetType(name string) xdr.AssetType {
 	}
 
 	return r
+}
+
+// GetOrderBook returns an OrderBookParams from the url params
+func (base *Base) GetOrderBook() (result OrderBookParams) {
+	if base.Err != nil {
+		return
+	}
+
+	result = OrderBookParams{
+		SellingType:   base.GetAssetType("selling_asset_type"),
+		SellingIssuer: base.GetString("selling_asset_issuer"),
+		SellingCode:   base.GetString("selling_asset_code"),
+		BuyingType:    base.GetAssetType("buying_asset_type"),
+		BuyingIssuer:  base.GetString("buying_asset_issuer"),
+		BuyingCode:    base.GetString("buying_asset_code"),
+	}
+
+	if base.Err != nil {
+		goto InvalidOrderBook
+	}
+
+	if result.SellingType != xdr.AssetTypeAssetTypeNative {
+		if result.SellingCode == "" {
+			goto InvalidOrderBook
+		}
+
+		if result.SellingIssuer == "" {
+			goto InvalidOrderBook
+		}
+	}
+
+	if result.BuyingType != xdr.AssetTypeAssetTypeNative {
+		if result.BuyingCode == "" {
+			goto InvalidOrderBook
+		}
+
+		if result.BuyingIssuer == "" {
+			goto InvalidOrderBook
+		}
+	}
+
+	return
+
+InvalidOrderBook:
+	base.Err = &problem.P{
+		Type:   "invalid_order_book",
+		Title:  "Invalid Order Book Parameters",
+		Status: http.StatusBadRequest,
+		Detail: "The parameters that specify what order book to view are invalid in some way. " +
+			"Please ensure that your type parameters (selling_asset_type and buying_asset_type) are one the " +
+			"following valid values: native, credit_alphanum4, credit_alphanum12.  Also ensure that you " +
+			"have specified selling_asset_code and selling_issuer if selling_asset_type is not 'native', as well " +
+			"as buying_asset_code and buying_issuer if buying_asset_type is not 'native'",
+	}
+
+	return
 }
 
 // Path returns the current action's path, as determined by the http.Request of

--- a/src/github.com/stellar/horizon/actions_order_book.go
+++ b/src/github.com/stellar/horizon/actions_order_book.go
@@ -1,12 +1,8 @@
 package horizon
 
 import (
-	"net/http"
-
 	"github.com/stellar/horizon/db"
 	"github.com/stellar/horizon/render/hal"
-	"github.com/stellar/horizon/render/problem"
-	"github.com/stellar/go-stellar-base/xdr"
 )
 
 // OrderBookShowAction renders a account summary found by its address.
@@ -19,52 +15,16 @@ type OrderBookShowAction struct {
 
 // LoadQuery sets action.Query from the request params
 func (action *OrderBookShowAction) LoadQuery() {
+	params := action.GetOrderBook()
+
 	action.Query = db.OrderBookSummaryQuery{
 		SqlQuery:      action.App.CoreQuery(),
-		SellingType:   action.GetAssetType("selling_asset_type"),
-		SellingIssuer: action.GetString("selling_asset_issuer"),
-		SellingCode:   action.GetString("selling_asset_code"),
-		BuyingType:    action.GetAssetType("buying_asset_type"),
-		BuyingIssuer:  action.GetString("buying_asset_issuer"),
-		BuyingCode:    action.GetString("buying_asset_code"),
-	}
-
-	if action.Err != nil {
-		goto InvalidOrderBook
-	}
-
-	if action.Query.SellingType != xdr.AssetTypeAssetTypeNative {
-		if action.Query.SellingCode == "" {
-			goto InvalidOrderBook
-		}
-
-		if action.Query.SellingIssuer == "" {
-			goto InvalidOrderBook
-		}
-	}
-
-	if action.Query.BuyingType != xdr.AssetTypeAssetTypeNative {
-		if action.Query.BuyingCode == "" {
-			goto InvalidOrderBook
-		}
-
-		if action.Query.BuyingIssuer == "" {
-			goto InvalidOrderBook
-		}
-	}
-
-	return
-
-InvalidOrderBook:
-	action.Err = &problem.P{
-		Type:   "invalid_order_book",
-		Title:  "Invalid Order Book Parameters",
-		Status: http.StatusBadRequest,
-		Detail: "The parameters that specify what order book to view are invalid in some way. " +
-			"Please ensure that your type parameters (selling_asset_type and buying_asset_type) are one the " +
-			"following valid values: native, credit_alphanum4, credit_alphanum12.  Also ensure that you " +
-			"have specified selling_asset_code and selling_issuer if selling_asset_type is not 'native', as well " +
-			"as buying_asset_code and buying_issuer if buying_asset_type is not 'native'",
+		SellingType:   params.SellingType,
+		SellingIssuer: params.SellingIssuer,
+		SellingCode:   params.SellingCode,
+		BuyingType:    params.BuyingType,
+		BuyingIssuer:  params.BuyingIssuer,
+		BuyingCode:    params.BuyingCode,
 	}
 
 	return

--- a/src/github.com/stellar/horizon/actions_trade.go
+++ b/src/github.com/stellar/horizon/actions_trade.go
@@ -1,0 +1,57 @@
+package horizon
+
+import (
+	"github.com/stellar/horizon/db"
+	"github.com/stellar/horizon/render/hal"
+	_ "github.com/stellar/horizon/render/sse"
+)
+
+// TradeIndexAction renders a page of effect resources, filtered to include
+// only trades, identified by a normal page query and optionally filtered by an account
+// or order book
+type TradeIndexAction struct {
+	Action
+	Query   db.EffectPageQuery
+	Records []db.EffectRecord
+	Page    hal.Page
+}
+
+// JSON is a method for actions.JSON
+func (action *TradeIndexAction) JSON() {
+	action.Do(
+		action.LoadQuery,
+		action.LoadRecords,
+		action.LoadPage,
+		func() {
+			hal.Render(action.W, action.Page)
+		},
+	)
+}
+
+// LoadQuery sets action.Query from the request params
+func (action *TradeIndexAction) LoadQuery() {
+	action.Query = db.EffectPageQuery{
+		SqlQuery:  action.App.HistoryQuery(),
+		PageQuery: action.GetPageQuery(),
+		Filter:    &db.EffectTypeFilter{db.EffectTrade},
+	}
+
+	if address := action.GetString("account_id"); address != "" {
+		action.Query.Filter = db.FilterAll(
+			action.Query.Filter,
+			&db.EffectAccountFilter{action.Query.SqlQuery, address},
+		)
+		return
+	}
+
+}
+
+// LoadRecords populates action.Records
+func (action *TradeIndexAction) LoadRecords() {
+	action.Err = db.Select(action.Ctx, action.Query, &action.Records)
+}
+
+// LoadPage populates action.Page
+func (action *TradeIndexAction) LoadPage() {
+	action.Page, action.Err = NewTradeResourcePage(action.Records, action.Query.PageQuery, action.Path())
+}

--- a/src/github.com/stellar/horizon/actions_trade.go
+++ b/src/github.com/stellar/horizon/actions_trade.go
@@ -44,6 +44,24 @@ func (action *TradeIndexAction) LoadQuery() {
 		return
 	}
 
+	// HACK: see if it looks like we're specifying an order book on params
+	// try to load it if so
+	if action.GetString("selling_asset_type") != "" {
+		params := action.GetOrderBook()
+
+		action.Query.Filter = db.FilterAll(
+			action.Query.Filter,
+			&db.EffectOrderBookFilter{
+				SellingType:   params.SellingType,
+				SellingCode:   params.SellingCode,
+				SellingIssuer: params.SellingIssuer,
+				BuyingType:    params.BuyingType,
+				BuyingCode:    params.BuyingCode,
+				BuyingIssuer:  params.BuyingIssuer,
+			},
+		)
+	}
+
 }
 
 // LoadRecords populates action.Records

--- a/src/github.com/stellar/horizon/actions_trade_test.go
+++ b/src/github.com/stellar/horizon/actions_trade_test.go
@@ -20,5 +20,18 @@ func TestTradeActions(t *testing.T) {
 			So(w.Body, ShouldBePageOf, 1)
 		})
 
+		Convey("GET /order_book/trades", func() {
+			url := "/order_book/trades?" +
+				"selling_asset_type=credit_alphanum4&" +
+				"selling_asset_code=EUR&" +
+				"selling_asset_issuer=GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQOH2LHEDX3EKVIQRLMESGBG&" +
+				"buying_asset_type=credit_alphanum4&" +
+				"buying_asset_code=USD&" +
+				"buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
+
+			w := rh.Get(url, test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+		})
 	})
 }

--- a/src/github.com/stellar/horizon/actions_trade_test.go
+++ b/src/github.com/stellar/horizon/actions_trade_test.go
@@ -1,0 +1,24 @@
+package horizon
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stellar/horizon/test"
+	"testing"
+)
+
+func TestTradeActions(t *testing.T) {
+
+	Convey("Trade Actions:", t, func() {
+		test.LoadScenario("trades")
+		app := NewTestApp()
+		defer app.Close()
+		rh := NewRequestHelper(app)
+
+		Convey("GET /accounts/:account_id/trades", func() {
+			w := rh.Get("/accounts/GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2/trades", test.RequestHelperNoop)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body, ShouldBePageOf, 1)
+		})
+
+	})
+}

--- a/src/github.com/stellar/horizon/init_versions.go
+++ b/src/github.com/stellar/horizon/init_versions.go
@@ -1,10 +1,11 @@
 package horizon
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/stellar/horizon/log"
 	"io/ioutil"
 	"net/http"
-	"encoding/json"
 )
 
 func initStellarCoreVersion(app *App) {
@@ -12,16 +13,18 @@ func initStellarCoreVersion(app *App) {
 		return
 	}
 
-	resp, err := http.Get(fmt.Sprint(app.config.StellarCoreUrl,"/info"))
+	resp, err := http.Get(fmt.Sprint(app.config.StellarCoreUrl, "/info"))
 
 	if err != nil {
-		app.log.Panic(app.ctx, err)
+		log.Warnf(app.ctx, "could not load stellar-core version: %s", err)
+		return
 	}
 
 	defer resp.Body.Close()
 	contents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		app.log.Panic(app.ctx, err)
+		log.Warnf(app.ctx, "could not load stellar-core version: %s", err)
+		return
 	}
 
 	var responseJson map[string]*json.RawMessage

--- a/src/github.com/stellar/horizon/init_web.go
+++ b/src/github.com/stellar/horizon/init_web.go
@@ -89,6 +89,7 @@ func initWebActions(app *App) {
 	r.Get("/accounts/:account_id/payments", &PaymentsIndexAction{})
 	r.Get("/accounts/:account_id/effects", &EffectIndexAction{})
 	r.Get("/accounts/:account_id/offers", &OffersByAccountAction{})
+	r.Get("/accounts/:account_id/trades", &TradeIndexAction{})
 
 	// transaction actions
 	r.Get("/transactions", &TransactionIndexAction{})
@@ -107,6 +108,7 @@ func initWebActions(app *App) {
 
 	r.Get("/offers/:id", &NotImplementedAction{})
 	r.Get("/order_book", &OrderBookShowAction{})
+	r.Get("/order_book/trades", &TradeIndexAction{})
 
 	// horizon doesn't implement everything ruby-horizon did,
 	// so we reverse proxy if we can

--- a/src/github.com/stellar/horizon/main_generated.go
+++ b/src/github.com/stellar/horizon/main_generated.go
@@ -6,21 +6,28 @@ import (
 )
 
 // ServeHTTPC is a method for web.Handler
-func (action RootAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+func (action MetricsAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)
 	ap.Execute(&action)
 }
 
 // ServeHTTPC is a method for web.Handler
-func (action PaymentsIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+func (action AccountIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)
 	ap.Execute(&action)
 }
 
 // ServeHTTPC is a method for web.Handler
-func (action RateLimitExceededAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+func (action AccountShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action TradeIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)
 	ap.Execute(&action)
@@ -41,7 +48,56 @@ func (action LedgerShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *htt
 }
 
 // ServeHTTPC is a method for web.Handler
-func (action MetricsAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+func (action OrderBookShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action NotImplementedAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action OffersByAccountAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action RootAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action OperationIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action OperationShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action NotFoundAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+	ap := &action.Action
+	ap.Prepare(c, w, r)
+	ap.Execute(&action)
+}
+
+// ServeHTTPC is a method for web.Handler
+func (action RateLimitExceededAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)
 	ap.Execute(&action)
@@ -69,56 +125,7 @@ func (action EffectIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *ht
 }
 
 // ServeHTTPC is a method for web.Handler
-func (action NotFoundAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action OperationIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action OperationShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action OffersByAccountAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action AccountIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action AccountShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action NotImplementedAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
-	ap := &action.Action
-	ap.Prepare(c, w, r)
-	ap.Execute(&action)
-}
-
-// ServeHTTPC is a method for web.Handler
-func (action OrderBookShowAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
+func (action PaymentsIndexAction) ServeHTTPC(c web.C, w http.ResponseWriter, r *http.Request) {
 	ap := &action.Action
 	ap.Prepare(c, w, r)
 	ap.Execute(&action)

--- a/src/github.com/stellar/horizon/resource_trade.go
+++ b/src/github.com/stellar/horizon/resource_trade.go
@@ -1,0 +1,85 @@
+package horizon
+
+import (
+	"github.com/jagregory/halgo"
+	"github.com/stellar/horizon/db"
+	"github.com/stellar/horizon/render/hal"
+)
+
+// EffectResource is the json form of a row from the history_effects
+// table.
+type TradeResource struct {
+	halgo.Links
+	ID                string      `json:"id"`
+	PagingToken       string      `json:"paging_token"`
+	Seller            string      `json:"seller"`
+	SoldAssetType     interface{} `json:"sold_asset_type"`
+	SoldAssetCode     interface{} `json:"sold_asset_code,omitempty"`
+	SoldAssetIssuer   interface{} `json:"sold_asset_issuer,omitempty"`
+	Buyer             string      `json:"buyer"`
+	BoughtAssetType   interface{} `json:"bought_asset_type"`
+	BoughtAssetCode   interface{} `json:"bought_asset_code,omitempty"`
+	BoughtAssetIssuer interface{} `json:"bought_asset_issuer,omitempty"`
+}
+
+// NewTradeResource initializes a new resource from an EffectRecord
+func NewTradeResource(r db.EffectRecord) (result TradeResource, err error) {
+
+	// TODO: error out if the effect is not a trade effect
+
+	var details map[string]interface{}
+	details, err = r.Details()
+
+	if err != nil {
+		return
+	}
+
+	seller := details["seller"].(string)
+	//TODO: error out if the seller is not a string
+
+	result = TradeResource{
+		Links: halgo.Links{}.
+			Link("seller", "/accounts/%s", seller).
+			Link("buyer", "/accounts/%s", r.Account).
+			Link("order_book", "/order_book?TODO"),
+		ID:                r.PagingToken(),
+		PagingToken:       r.PagingToken(),
+		Seller:            seller,
+		SoldAssetType:     details["sold_asset_type"],
+		SoldAssetCode:     details["sold_asset_code"],
+		SoldAssetIssuer:   details["sold_asset_issuer"],
+		Buyer:             r.Account,
+		BoughtAssetType:   details["bought_asset_type"],
+		BoughtAssetCode:   details["bought_asset_code"],
+		BoughtAssetIssuer: details["bought_asset_issuer"],
+	}
+
+	return
+}
+
+// NewTradeResourcePage initialzed a hal.Page from s a slice of
+// EffectRecords
+func NewTradeResourcePage(records []db.EffectRecord, query db.PageQuery, path string) (hal.Page, error) {
+	fmts := path + "?order=%s&limit=%d&cursor=%s"
+	next, prev, err := query.GetContinuations(records)
+	if err != nil {
+		return hal.Page{}, err
+	}
+
+	resources := make([]interface{}, len(records))
+	for i, record := range records {
+		r, err := NewTradeResource(record)
+		if err != nil {
+			return hal.Page{}, err
+		}
+		resources[i] = r
+	}
+
+	return hal.Page{
+		Links: halgo.Links{}.
+			Self(fmts, query.Order, query.Limit, query.Cursor).
+			Link("next", fmts, next.Order, next.Limit, next.Cursor).
+			Link("prev", fmts, prev.Order, prev.Limit, prev.Cursor),
+		Records: resources,
+	}, nil
+}

--- a/src/github.com/stellar/horizon/resource_trade.go
+++ b/src/github.com/stellar/horizon/resource_trade.go
@@ -1,9 +1,14 @@
 package horizon
 
 import (
+	"errors"
 	"github.com/jagregory/halgo"
 	"github.com/stellar/horizon/db"
 	"github.com/stellar/horizon/render/hal"
+)
+
+var (
+	ErrInvalidTrade = errors.New("cannot create TradeResource from invalid effect")
 )
 
 // EffectResource is the json form of a row from the history_effects
@@ -25,7 +30,10 @@ type TradeResource struct {
 // NewTradeResource initializes a new resource from an EffectRecord
 func NewTradeResource(r db.EffectRecord) (result TradeResource, err error) {
 
-	// TODO: error out if the effect is not a trade effect
+	if r.Type != db.EffectTrade {
+		err = ErrInvalidTrade
+		return
+	}
 
 	var details map[string]interface{}
 	details, err = r.Details()
@@ -34,8 +42,11 @@ func NewTradeResource(r db.EffectRecord) (result TradeResource, err error) {
 		return
 	}
 
-	seller := details["seller"].(string)
-	//TODO: error out if the seller is not a string
+	seller, ok := details["seller"].(string)
+	if !ok {
+		err = ErrInvalidTrade
+		return
+	}
 
 	result = TradeResource{
 		Links: halgo.Links{}.


### PR DESCRIPTION
This PR add support for the "Trades by Account" and "Trades by order book" endpoints.  In service of that, this PR also:
- Adds a `actions.GetOrderBook` helper to extract parameters from the http request for an order book
- Adds `db.EffectOrderBookFilter`
