### PR TITLE
Rename type to type_i, type_s to type

### DIFF
--- a/docs/learn/tutorials/follow-received-payments.md
+++ b/docs/learn/tutorials/follow-received-payments.md
@@ -121,8 +121,8 @@ data: {"_links":{"effects":{"href":"/operations/713226564145153/effects/{?cursor
        "id":713226564145153,
        "paging_token":"713226564145153",
        "starting_balance":1e+09,
-       "type":0,
-       "type_s":"create_account"}
+       "type_i":0,
+       "type":"create_account"}
 ```
 
 Every time you receive a new payment you will get a new row of data. Payments is not the only endpoint that supports streaming. You can also stream transactions [/transactions](../../reference/transactions-all.md) and operations [/operations](../../reference/operations-all.md).
@@ -159,8 +159,8 @@ New payment:
   id: 713226564145153,
   paging_token: '713226564145153',
   starting_balance: 1000000000,
-  type: 0,
-  type_s: 'create_account' }
+  type_i: 0,
+  type: 'create_account' }
 ```
 
 ## Testing it out

--- a/docs/reference/effects-all.md
+++ b/docs/reference/effects-all.md
@@ -70,8 +70,8 @@ The list of effects.
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "279172878337-1",
         "starting_balance": "10000000.0",
-        "type": 0,
-        "type_s": "account_created"
+        "type_i": 0,
+        "type": "account_created"
       },
       {
         "_links": {
@@ -89,8 +89,8 @@ The list of effects.
         "amount": "10000000.0",
         "asset_type": "native",
         "paging_token": "279172878337-2",
-        "type": 3,
-        "type_s": "account_debited"
+        "type_i": 3,
+        "type": "account_debited"
       }
     ]
   },

--- a/docs/reference/effects-for-account.md
+++ b/docs/reference/effects-for-account.md
@@ -72,8 +72,8 @@ The list of effects.
         "account": "GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK",
         "paging_token": "214748368897-1",
         "starting_balance": "100.0",
-        "type": 0,
-        "type_s": "account_created"
+        "type_i": 0,
+        "type": "account_created"
       },
       {
         "_links": {
@@ -90,8 +90,8 @@ The list of effects.
         "account": "GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK",
         "paging_token": "214748368897-3",
         "public_key": "GC6NFQDTVH2YMVZSXJIVLCRHLFAOVOT32JMDFZJZ34QFSSVT7M5G2XFK",
-        "type": 10,
-        "type_s": "signer_created",
+        "type_i": 10,
+        "type": "signer_created",
         "weight": 2
       }
     ]

--- a/docs/reference/effects-for-ledger.md
+++ b/docs/reference/effects-for-ledger.md
@@ -71,8 +71,8 @@ This endpoint responds with a list of effects that occurred in the ledger. See [
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-1",
         "starting_balance": "10000000.0",
-        "type": 0,
-        "type_s": "account_created"
+        "type_i": 0,
+        "type": "account_created"
       },
       {
         "_links": {
@@ -90,8 +90,8 @@ This endpoint responds with a list of effects that occurred in the ledger. See [
         "amount": "10000000.0",
         "asset_type": "native",
         "paging_token": "141733924865-2",
-        "type": 3,
-        "type_s": "account_debited"
+        "type_i": 3,
+        "type": "account_debited"
       },
       {
         "_links": {
@@ -108,8 +108,8 @@ This endpoint responds with a list of effects that occurred in the ledger. See [
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-3",
         "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "type": 10,
-        "type_s": "signer_created",
+        "type_i": 10,
+        "type": "signer_created",
         "weight": 2
       }
     ]

--- a/docs/reference/effects-for-operation.md
+++ b/docs/reference/effects-for-operation.md
@@ -69,8 +69,8 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-1",
         "starting_balance": "10000000.0",
-        "type": 0,
-        "type_s": "account_created"
+        "type_i": 0,
+        "type": "account_created"
       },
       {
         "_links": {
@@ -88,8 +88,8 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
         "amount": "10000000.0",
         "asset_type": "native",
         "paging_token": "141733924865-2",
-        "type": 3,
-        "type_s": "account_debited"
+        "type_i": 3,
+        "type": "account_debited"
       },
       {
         "_links": {
@@ -106,8 +106,8 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-3",
         "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "type": 10,
-        "type_s": "signer_created",
+        "type_i": 10,
+        "type": "signer_created",
         "weight": 2
       }
     ]

--- a/docs/reference/effects-for-transaction.md
+++ b/docs/reference/effects-for-transaction.md
@@ -69,8 +69,8 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-1",
         "starting_balance": "10000000.0",
-        "type": 0,
-        "type_s": "account_created"
+        "type_i": 0,
+        "type": "account_created"
       },
       {
         "_links": {
@@ -88,8 +88,8 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
         "amount": "10000000.0",
         "asset_type": "native",
         "paging_token": "141733924865-2",
-        "type": 3,
-        "type_s": "account_debited"
+        "type_i": 3,
+        "type": "account_debited"
       },
       {
         "_links": {
@@ -106,8 +106,8 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-3",
         "public_key": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
-        "type": 10,
-        "type_s": "signer_created",
+        "type_i": 10,
+        "type": "signer_created",
         "weight": 2
       }
     ]

--- a/docs/reference/operations-all.md
+++ b/docs/reference/operations-all.md
@@ -82,8 +82,8 @@ This endpoint responds with a list of operations. See [operation resource](./res
         "id": 77309415424,
         "paging_token": "77309415424",
         "starting_balance": 1e+14,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       },
       {
         "_links": {
@@ -109,8 +109,8 @@ This endpoint responds with a list of operations. See [operation resource](./res
         "id": 463856472064,
         "paging_token": "463856472064",
         "starting_balance": 1e+09,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },
@@ -155,8 +155,8 @@ This endpoint responds with a list of operations. See [operation resource](./res
   "id": 77309415424,
   "paging_token": "77309415424",
   "starting_balance": 1e+14,
-  "type": 0,
-  "type_s": "create_account"
+  "type_i": 0,
+  "type": "create_account"
 }
 ```
 

--- a/docs/reference/operations-for-account.md
+++ b/docs/reference/operations-for-account.md
@@ -79,8 +79,8 @@ This endpoint responds with a list of operations that affected the given account
         "id": 46316927324160,
         "paging_token": "46316927324160",
         "starting_balance": 1e+09,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },
@@ -125,8 +125,8 @@ This endpoint responds with a list of operations that affected the given account
   "id": 77309415424,
   "paging_token": "77309415424",
   "starting_balance": 1e+14,
-  "type": 0,
-  "type_s": "create_account"
+  "type_i": 0,
+  "type": "create_account"
 }
 ```
 

--- a/docs/reference/operations-for-ledger.md
+++ b/docs/reference/operations-for-ledger.md
@@ -76,8 +76,8 @@ This endpoint responds with a list of operations in a given ledger.  See [operat
         "id": 77309415424,
         "paging_token": "77309415424",
         "starting_balance": 1e+14,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },

--- a/docs/reference/operations-for-transaction.md
+++ b/docs/reference/operations-for-transaction.md
@@ -76,8 +76,8 @@ This endpoint responds with a list of operations that are part of a given transa
         "id": 352573865332736,
         "paging_token": "352573865332736",
         "starting_balance": 1e+09,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },

--- a/docs/reference/operations-single.md
+++ b/docs/reference/operations-single.md
@@ -72,8 +72,8 @@ This endpoint responds with a single Operation.  See [operation resource](./reso
   "id": 77309415424,
   "paging_token": "77309415424",
   "starting_balance": 1e+14,
-  "type": 0,
-  "type_s": "create_account"
+  "type_i": 0,
+  "type": "create_account"
 }
 ```
 

--- a/docs/reference/payments-all.md
+++ b/docs/reference/payments-all.md
@@ -81,8 +81,8 @@ This endpoint responds with a list of payments. See [operation resource](./resou
         "id": 77309415424,
         "paging_token": "77309415424",
         "starting_balance": 1e+14,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       },
       {
         "_links": {
@@ -108,8 +108,8 @@ This endpoint responds with a list of payments. See [operation resource](./resou
         "id": 463856472064,
         "paging_token": "463856472064",
         "starting_balance": 1e+09,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },
@@ -154,8 +154,8 @@ This endpoint responds with a list of payments. See [operation resource](./resou
   "id": 77309415424,
   "paging_token": "77309415424",
   "starting_balance": 1e+14,
-  "type": 0,
-  "type_s": "create_account"
+  "type_i": 0,
+  "type": "create_account"
 }
 ```
 

--- a/docs/reference/payments-for-account.md
+++ b/docs/reference/payments-for-account.md
@@ -73,8 +73,8 @@ This endpoint responds with a [page](./resources/page.md) of [payment operations
       },
       "id": 12884905984,
       "paging_token": "12884905984",
-      "type": 0,
-      "type_s": "payment",
+      "type_i": 0,
+      "type": "payment",
       "sender": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
       "receiver": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
       "asset": {
@@ -124,8 +124,8 @@ This endpoint responds with a [page](./resources/page.md) of [payment operations
   "id": 77309415424,
   "paging_token": "77309415424",
   "starting_balance": 1e+14,
-  "type": 0,
-  "type_s": "create_account"
+  "type_i": 0,
+  "type": "create_account"
 }
 ```
 

--- a/docs/reference/payments-for-ledger.md
+++ b/docs/reference/payments-for-ledger.md
@@ -76,8 +76,8 @@ This endpoint responds with a list of payment operations in a given ledger.  See
         "id": 77309415424,
         "paging_token": "77309415424",
         "starting_balance": 1e+14,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },

--- a/docs/reference/payments-for-transaction.md
+++ b/docs/reference/payments-for-transaction.md
@@ -75,8 +75,8 @@ This endpoint responds with a list of payments operations that are part of a giv
         "id": 46428596473856,
         "paging_token": "46428596473856",
         "starting_balance": 1e+09,
-        "type": 0,
-        "type_s": "create_account"
+        "type_i": 0,
+        "type": "create_account"
       }
     ]
   },

--- a/docs/reference/resources/effect.md
+++ b/docs/reference/resources/effect.md
@@ -88,8 +88,8 @@ Attributes depend on effect type.
         "account": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
         "paging_token": "141733924865-1",
         "starting_balance": "10000000.0",
-        "type": 0,
-        "type_s": "account_created"
+        "type_i": 0,
+        "type": "account_created"
       }
     ]
   },

--- a/docs/reference/resources/operation.md
+++ b/docs/reference/resources/operation.md
@@ -12,18 +12,18 @@ To learn more about the concept of operations in the Stellar network, take a loo
 
 There are 10 different operation types:
 
-|     type_s           | type | description |
-| -------------------- | ---- |-------------|
-| [CREATE_ACCOUNT](#create-account)       |    0 | Creates a new account in Stellar network.
-| [PAYMENT](#payment)              |    1 | Sends a simple payment between two accounts in Stellar network.
-| [PATH_PAYMENT](#path-payment)         |    2 | Sends a path payment between two accounts in the Stellar network.
-| [MANAGE_OFFER](#manage-offer)         |    3 | Creates, updates or deletes an offer in the Stellar network.
-| [CREATE_PASSIVE_OFFER](#create-passive-offer) |    4 | Creates an offer that won't consume a counter offer that exactly matches this offer.
-| [SET_OPTIONS](#set-options)          |    5 | Sets account options (inflation destination, adding signers, etc.)
-| [CHANGE_TRUST](#change-trust)         |    6 | Creates, updates or deletes a trust line.
-| [ALLOW_TRUST](#allow-trust)          |    7 | Updates the "authorized" flag of an existing trust line this is called by the issuer of the related asset.
-| [ACCOUNT_MERGE](#account-merge)        |    8 | Deletes account and transfers remaining balance to destination account.
-| [INFLATION](#inflation)            |    9 | Runs inflation.
+| type                                          | type | description                                                                                                |
+|-----------------------------------------------|------|------------------------------------------------------------------------------------------------------------|
+| [CREATE_ACCOUNT](#create-account)             | 0    | Creates a new account in Stellar network.
+| [PAYMENT](#payment)                           | 1    | Sends a simple payment between two accounts in Stellar network.
+| [PATH_PAYMENT](#path-payment)                 | 2    | Sends a path payment between two accounts in the Stellar network.
+| [MANAGE_OFFER](#manage-offer)                 | 3    | Creates, updates or deletes an offer in the Stellar network.
+| [CREATE_PASSIVE_OFFER](#create-passive-offer) | 4    | Creates an offer that won't consume a counter offer that exactly matches this offer.
+| [SET_OPTIONS](#set-options)                   | 5    | Sets account options (inflation destination, adding signers, etc.)
+| [CHANGE_TRUST](#change-trust)                 | 6    | Creates, updates or deletes a trust line.
+| [ALLOW_TRUST](#allow-trust)                   | 7    | Updates the "authorized" flag of an existing trust line this is called by the issuer of the related asset.
+| [ACCOUNT_MERGE](#account-merge)               | 8    | Deletes account and transfers remaining balance to destination account.
+| [INFLATION](#inflation)                       | 9    | Runs inflation.
 
 
 Every operation type shares a set of common attributes and links, some operations also contain
@@ -33,12 +33,12 @@ additional attributes and links specific to that operation type.
 
 ## Common Attributes
 
-|               |  Type  |                                                                                                                            |
-| ------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
-| id            | number | The canonical id of this operation, suitable for use as the :id parameter for url templates that require an operation's ID. |
-| paging_token  | any    | A [paging token](./page.md) suitable for use as a `cursor` parameter. |
-| type          | number | Specifies the type of operation, See "Types" section below for reference.                                                  |
-| type_s        | string | A string representation of the type of operation.                                                                           |
+|              | Type   |                                                                                                                             |
+|--------------|--------|-----------------------------------------------------------------------------------------------------------------------------|
+| id           | number | The canonical id of this operation, suitable for use as the :id parameter for url templates that require an operation's ID. |
+| paging_token | any    | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                       |
+| type         | string | A string representation of the type of operation.                                                                           |
+| type_i       | number | Specifies the type of operation, See "Types" section below for reference.                                                   |
 
 ## Common Links
 
@@ -94,8 +94,8 @@ Create Account operation represents a new account creation.
   "id": 402494270214144,
   "paging_token": "402494270214144",
   "starting_balance": "10000.0",
-  "type": 0,
-  "type_s": "create_account"
+  "type_i": 0,
+  "type": "create_account"
 }
 ```
 
@@ -151,8 +151,8 @@ can be either a simple native asset payment or a fiat asset payment.
   "id": 58402965295104,
   "paging_token": "58402965295104",
   "to": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
-  "type": 1,
-  "type_s": "payment"
+  "type_i": 1,
+  "type": "payment"
 }
 ```
 
@@ -211,8 +211,8 @@ A path payment operation represents a payment from one account to another throug
   "send_asset_type": "credit_alphanum4",
   "source_amount": "10.0",
   "to": "GA5WBPYA5Y4WAEHXWR2UKO2UO4BUGHUQ74EUPKON2QHV4WRHOIRNKKH2",
-  "type": 2,
-  "type_s": "path_payment"
+  "type_i": 2,
+  "type": "path_payment"
 }
 ```
 
@@ -283,8 +283,8 @@ offers or payments, this offer can potentially be filled.
   "selling_asset_code": "YEN",
   "selling_asset_issuer": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
   "selling_asset_type": "credit_alphanum4",
-  "type": 3,
-  "type_s": "manage_offer"
+  "type_i": 3,
+  "type": "manage_offer"
 }
 ```
 
@@ -332,8 +332,8 @@ As in [Manage Offer](#manage-offer) operation.
     "n": 1
   },
   "selling_asset_type": "native",
-  "type": 4,
-  "type_s": "create_passive_offer"
+  "type_i": 4,
+  "type": "create_passive_offer"
 }
 ```
 
@@ -401,8 +401,8 @@ Use “Set Options” operation to set following options to your account:
   "set_flags_s": [
     "auth_required_flag"
   ],
-  "type": 5,
-  "type_s": "set_options"
+  "type_i": 5,
+  "type": "set_options"
 }
 ```
 
@@ -452,8 +452,8 @@ Use “Change Trust” operation to create/update/delete a trust line from the s
   "paging_token": "574731048718337",
   "trustee": "GAC2ZUXVI5266NMMGDPBMXHH4BTZKJ7MMTGXRZGX2R5YLMFRYLJ7U5EA",
   "trustor": "GDVXG2FMFFSUMMMBIUEMWPZAIU2FNCH7QNGJMWRXRD6K5FZK5KJS4DDR",
-  "type": 6,
-  "type_s": "change_trust"
+  "type_i": 6,
+  "type": "change_trust"
 }
 ```
 
@@ -505,8 +505,8 @@ Heads up! Unless the issuing account has `AUTH_REVOCABLE_FLAG` set than the "aut
   "paging_token": "34359742465",
   "trustee": "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4",
   "trustor": "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON",
-  "type": 7,
-  "type_s": "allow_trust"
+  "type_i": 7,
+  "type": "allow_trust"
 }
 ```
 
@@ -546,8 +546,8 @@ Removes the account and transfers all remaining XLM to the destination account.
   "id": 799357838299137,
   "into": "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K",
   "paging_token": "799357838299137",
-  "type": 8,
-  "type_s": "account_merge"
+  "type_i": 8,
+  "type": "account_merge"
 }
 ```
 
@@ -580,8 +580,8 @@ Runs inflation.
   },
   "id": 12884914177,
   "paging_token": "12884914177",
-  "type": 9,
-  "type_s": "inflation"
+  "type_i": 9,
+  "type": "inflation"
 }
 ```
 

--- a/docs/reference/resources/page.md
+++ b/docs/reference/resources/page.md
@@ -58,8 +58,8 @@ A page provides a couple of links to ease in iteration.
         },
         "id": 12884905984,
         "paging_token": "12884905984",
-        "type": 0,
-        "type_s": "payment",
+        "type_i": 0,
+        "type": "payment",
         "sender": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
         "receiver": "GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU",
         "asset": {

--- a/src/github.com/stellar/horizon/render/sse/main.go
+++ b/src/github.com/stellar/horizon/render/sse/main.go
@@ -82,6 +82,7 @@ func (s *Streamer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func WritePreamble(ctx context.Context, w http.ResponseWriter) bool {
+
 	_, flushable := w.(http.Flusher)
 
 	if !flushable {

--- a/src/github.com/stellar/horizon/resource_effect.go
+++ b/src/github.com/stellar/horizon/resource_effect.go
@@ -50,16 +50,16 @@ func NewEffectResource(op db.EffectRecord) (EffectResource, error) {
 		Link("operation", "/operations/%d", op.HistoryOperationID).
 		Items
 	result["paging_token"] = op.PagingToken()
-	result["type"] = op.Type
+	result["type_i"] = op.Type
 	result["account"] = op.Account
 
 	ts, ok := effectResourceTypeNames[op.Type]
 
 	if ok {
-		result["type_s"] = ts
+		result["type"] = ts
 	} else {
 		//TODO: log a warning when we encounter this... it implies our code is out of date
-		result["type_s"] = "unknown"
+		result["type"] = "unknown"
 	}
 
 	return result, nil

--- a/src/github.com/stellar/horizon/resource_operation.go
+++ b/src/github.com/stellar/horizon/resource_operation.go
@@ -51,14 +51,14 @@ func NewOperationResource(op db.OperationRecord) (OperationResource, error) {
 	result["id"] = op.Id
 	result["source_account"] = op.SourceAccount
 	result["paging_token"] = op.PagingToken()
-	result["type"] = op.Type
+	result["type_i"] = op.Type
 
 	ts, ok := operationResourceTypeNames[op.Type]
 
 	if ok {
-		result["type_s"] = ts
+		result["type"] = ts
 	} else {
-		result["type_s"] = "unknown"
+		result["type"] = "unknown"
 	}
 
 	return result, nil


### PR DESCRIPTION
We’ll emphasize using the string names as identifying values from now
on, but we still leave the numerical representation for those that want it.

Closed #154 
