### PR TITLE
Fix order book summary resource

### DIFF
--- a/src/github.com/stellar/horizon/actions_order_book_test.go
+++ b/src/github.com/stellar/horizon/actions_order_book_test.go
@@ -105,6 +105,13 @@ func TestOrderBookActions(t *testing.T) {
 			So(len(result.Asks), ShouldEqual, 3)
 			So(len(result.Bids), ShouldEqual, 3)
 
+			So(result.Asks[0].Amount, ShouldEqual, "1.0000000")
+			So(result.Asks[1].Amount, ShouldEqual, "11.0000000")
+			So(result.Asks[2].Amount, ShouldEqual, "200.0000000")
+
+			So(result.Bids[0].Amount, ShouldEqual, "10.0000000")
+			So(result.Bids[1].Amount, ShouldEqual, "100.0000000")
+			So(result.Bids[2].Amount, ShouldEqual, "1000.0000000")
 		})
 	})
 }

--- a/src/github.com/stellar/horizon/db/record_price_level.go
+++ b/src/github.com/stellar/horizon/db/record_price_level.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"github.com/stellar/go-stellar-base/amount"
+	"github.com/stellar/go-stellar-base/xdr"
 	"math/big"
 )
 
@@ -22,4 +24,9 @@ func (p *PriceLevelRecord) InvertPricef() float64 {
 // PriceAsString returns the price as a string
 func (p *PriceLevelRecord) PriceAsString() string {
 	return big.NewRat(int64(p.Pricen), int64(p.Priced)).FloatString(7)
+}
+
+// PriceAsString returns the price as a string
+func (p *PriceLevelRecord) AmountAsString() string {
+	return amount.String(xdr.Int64(p.Amount))
 }

--- a/src/github.com/stellar/horizon/db/record_price_level.go
+++ b/src/github.com/stellar/horizon/db/record_price_level.go
@@ -26,7 +26,8 @@ func (p *PriceLevelRecord) PriceAsString() string {
 	return big.NewRat(int64(p.Pricen), int64(p.Priced)).FloatString(7)
 }
 
-// PriceAsString returns the price as a string
+// AmountAsString returns the amount as a string, formatted using
+// the amount.String() utility from go-stellar-base.
 func (p *PriceLevelRecord) AmountAsString() string {
 	return amount.String(xdr.Int64(p.Amount))
 }

--- a/src/github.com/stellar/horizon/resource_order_book.go
+++ b/src/github.com/stellar/horizon/resource_order_book.go
@@ -25,8 +25,8 @@ type PriceLevelResource struct {
 // AssetResource is the display form of a Asset in the stellar network
 type AssetResource struct {
 	AssetType   string `json:"asset_type"`
-	AssetCode   string `json:"asset_code,ignoreempty"`
-	AssetIssuer string `json:"asset_issuer,ignoreempty"`
+	AssetCode   string `json:"asset_code,omitempty"`
+	AssetIssuer string `json:"asset_issuer,omitempty"`
 }
 
 // NewOrderBookSummaryResource converts the provided query and summary into a json object
@@ -44,7 +44,7 @@ func NewOrderBookSummaryResource(query *db.OrderBookSummaryQuery, summary db.Ord
 
 	result = OrderBookSummaryResource{
 		Bids: newPriceLevelResources(summary.Bids()),
-		Asks: newPriceLevelResources(summary.Bids()),
+		Asks: newPriceLevelResources(summary.Asks()),
 		Selling: AssetResource{
 			AssetType:   bt,
 			AssetCode:   query.SellingCode,
@@ -65,7 +65,8 @@ func newPriceLevelResources(records []db.OrderBookSummaryPriceLevelRecord) []Pri
 
 	for i, rec := range records {
 		result[i] = PriceLevelResource{
-			Price: rec.PriceAsString(),
+			Price:  rec.PriceAsString(),
+			Amount: rec.AmountAsString(),
 			PriceR: PriceResource{
 				N: rec.Pricen,
 				D: rec.Priced,


### PR DESCRIPTION
This PR contains a two fixes for the order book summary endpoint:
- Properly shows Asks in the "asks" field
- Populate "amount" field
