### PR TITLE
Fix overflow error on effect queries and delint TotalOrderID

### DIFF
--- a/src/github.com/stellar/horizon/action.go
+++ b/src/github.com/stellar/horizon/action.go
@@ -44,7 +44,7 @@ func (action *Action) GetPagingParams() (cursor string, order string, limit int3
 	cursor, order, limit = action.Base.GetPagingParams()
 
 	if cursor == "now" {
-		tid := db.TotalOrderId{
+		tid := db.TotalOrderID{
 			LedgerSequence:   action.App.latestLedgerState.HorizonSequence,
 			TransactionOrder: db.TotalOrderTransactionMask,
 			OperationOrder:   db.TotalOrderOperationMask,

--- a/src/github.com/stellar/horizon/db/query_effect_page_test.go
+++ b/src/github.com/stellar/horizon/db/query_effect_page_test.go
@@ -111,7 +111,7 @@ func TestEffectPageQuery(t *testing.T) {
 			So(len(records), ShouldEqual, 2)
 
 			for _, r := range records {
-				toid := ParseTotalOrderId(r.HistoryOperationID)
+				toid := ParseTotalOrderID(r.HistoryOperationID)
 				So(toid.LedgerSequence, ShouldEqual, 3)
 			}
 		})
@@ -124,7 +124,7 @@ func TestEffectPageQuery(t *testing.T) {
 			So(len(records), ShouldEqual, 3)
 
 			for _, r := range records {
-				toid := ParseTotalOrderId(r.HistoryOperationID)
+				toid := ParseTotalOrderID(r.HistoryOperationID)
 				So(toid.LedgerSequence, ShouldEqual, 2)
 				So(toid.TransactionOrder, ShouldEqual, 1)
 				So(toid.OperationOrder, ShouldEqual, 1)
@@ -140,7 +140,7 @@ func TestEffectPageQuery(t *testing.T) {
 			So(len(records), ShouldEqual, 3)
 
 			for _, r := range records {
-				toid := ParseTotalOrderId(r.HistoryOperationID)
+				toid := ParseTotalOrderID(r.HistoryOperationID)
 				So(toid.LedgerSequence, ShouldEqual, 2)
 				So(toid.TransactionOrder, ShouldEqual, 1)
 			}

--- a/src/github.com/stellar/horizon/db/query_operation_page.go
+++ b/src/github.com/stellar/horizon/db/query_operation_page.go
@@ -68,8 +68,8 @@ func (q OperationPageQuery) Select(ctx context.Context, dest interface{}) error 
 		if err != nil {
 			return err
 		}
-		start := TotalOrderId{LedgerSequence: q.LedgerSequence}
-		end := TotalOrderId{LedgerSequence: q.LedgerSequence + 1}
+		start := TotalOrderID{LedgerSequence: q.LedgerSequence}
+		end := TotalOrderID{LedgerSequence: q.LedgerSequence + 1}
 		sql = sql.Where("hop.id >= ? AND hop.id < ?", start.ToInt64(), end.ToInt64())
 	}
 
@@ -82,7 +82,7 @@ func (q OperationPageQuery) Select(ctx context.Context, dest interface{}) error 
 			return err
 		}
 
-		start := ParseTotalOrderId(tx.Id)
+		start := ParseTotalOrderID(tx.Id)
 		end := start
 		end.TransactionOrder++
 		sql = sql.Where("hop.id >= ? AND hop.id < ?", start.ToInt64(), end.ToInt64())

--- a/src/github.com/stellar/horizon/db/query_operation_page_test.go
+++ b/src/github.com/stellar/horizon/db/query_operation_page_test.go
@@ -90,7 +90,7 @@ func TestOperationPageQuery(t *testing.T) {
 			So(len(records), ShouldEqual, 3)
 
 			for _, r := range records {
-				toid := ParseTotalOrderId(r.TransactionId)
+				toid := ParseTotalOrderID(r.TransactionId)
 				So(toid.LedgerSequence, ShouldEqual, 2)
 			}
 		})

--- a/src/github.com/stellar/horizon/db/record_effect.go
+++ b/src/github.com/stellar/horizon/db/record_effect.go
@@ -113,8 +113,8 @@ type EffectLedgerFilter struct {
 }
 
 func (f *EffectLedgerFilter) Apply(ctx context.Context, sql sq.SelectBuilder) (sq.SelectBuilder, error) {
-	start := TotalOrderId{LedgerSequence: f.LedgerSequence}
-	end := TotalOrderId{LedgerSequence: f.LedgerSequence + 1}
+	start := TotalOrderID{LedgerSequence: f.LedgerSequence}
+	end := TotalOrderID{LedgerSequence: f.LedgerSequence + 1}
 	return sql.Where(
 		"(heff.history_operation_id >= ? AND heff.history_operation_id < ?)",
 		start.ToInt64(),
@@ -137,7 +137,7 @@ func (f *EffectTransactionFilter) Apply(ctx context.Context, sql sq.SelectBuilde
 		return sql, nil
 	}
 
-	start := ParseTotalOrderId(tx.Id)
+	start := ParseTotalOrderID(tx.Id)
 	end := start
 	end.TransactionOrder++
 	return sql.Where(
@@ -154,9 +154,9 @@ type EffectOperationFilter struct {
 }
 
 func (f *EffectOperationFilter) Apply(ctx context.Context, sql sq.SelectBuilder) (sq.SelectBuilder, error) {
-	start := ParseTotalOrderId(f.OperationID)
+	start := ParseTotalOrderID(f.OperationID)
 	end := start
-	end.OperationOrder++
+	end.IncOperationOrder()
 	return sql.Where(
 		"(heff.history_operation_id >= ? AND heff.history_operation_id < ?)",
 		start.ToInt64(),
@@ -190,14 +190,14 @@ func (f *EffectOrderBookFilter) Apply(ctx context.Context, in sq.SelectBuilder) 
 
 	if f.SellingType == xdr.AssetTypeAssetTypeNative {
 		sql = sql.Where(`
-				(heff.details->>'sold_asset_type' = ? 
+				(heff.details->>'sold_asset_type' = ?
 		AND heff.details ?? 'sold_asset_code' = false
 		AND heff.details ?? 'sold_asset_issuer' = false)`,
 			sellingType,
 		)
 	} else {
 		sql = sql.Where(`
-				(heff.details->>'sold_asset_type' = ? 
+				(heff.details->>'sold_asset_type' = ?
 		AND heff.details->>'sold_asset_code' = ?
 		AND heff.details->>'sold_asset_issuer' = ?)`,
 			sellingType,
@@ -208,14 +208,14 @@ func (f *EffectOrderBookFilter) Apply(ctx context.Context, in sq.SelectBuilder) 
 
 	if f.BuyingType == xdr.AssetTypeAssetTypeNative {
 		sql = sql.Where(`
-				(heff.details->>'bought_asset_type' = ? 
-		AND heff.details ?? 'bought_asset_code' = false 
+				(heff.details->>'bought_asset_type' = ?
+		AND heff.details ?? 'bought_asset_code' = false
 		AND heff.details ?? 'bought_asset_issuer' = false)`,
 			buyingType,
 		)
 	} else {
 		sql = sql.Where(`
-				(heff.details->>'bought_asset_type' = ? 
+				(heff.details->>'bought_asset_type' = ?
 		AND heff.details->>'bought_asset_code' = ?
 		AND heff.details->>'bought_asset_issuer' = ?)`,
 			buyingType,

--- a/src/github.com/stellar/horizon/db/total_order_id_test.go
+++ b/src/github.com/stellar/horizon/db/total_order_id_test.go
@@ -8,77 +8,87 @@ import (
 	"testing"
 )
 
-func TestTotalOrderId(t *testing.T) {
+func TestTotalOrderID(t *testing.T) {
 	ledger := int64(4294967296) // ledger sequence 1
 	tx := int64(4096)           // tx index 1
 	op := int64(1)              // op index 1
 
-	Convey("TotalOrderId.ToInt64", t, func() {
+	Convey("TotalOrderID.ToInt64", t, func() {
 		Convey("accomodates 12-bits of precision for the operation", func() {
-			So(TotalOrderId{0, 0, 1}.ToInt64(), ShouldEqual, 1)
-			So(TotalOrderId{0, 0, 4095}.ToInt64(), ShouldEqual, 4095)
-			So(func() { TotalOrderId{0, 0, 4096}.ToInt64() }, ShouldPanic)
+			So((&TotalOrderID{0, 0, 1}).ToInt64(), ShouldEqual, 1)
+			So((&TotalOrderID{0, 0, 4095}).ToInt64(), ShouldEqual, 4095)
+			So(func() { (&TotalOrderID{0, 0, 4096}).ToInt64() }, ShouldPanic)
 		})
 
 		Convey("accomodates 20-bits of precision for the transaction", func() {
-			So(TotalOrderId{0, 1, 0}.ToInt64(), ShouldEqual, 4096)
-			So(TotalOrderId{0, 1048575, 0}.ToInt64(), ShouldEqual, 4294963200)
-			So(func() { TotalOrderId{0, 1048576, 0}.ToInt64() }, ShouldPanic)
+			So((&TotalOrderID{0, 1, 0}).ToInt64(), ShouldEqual, 4096)
+			So((&TotalOrderID{0, 1048575, 0}).ToInt64(), ShouldEqual, 4294963200)
+			So(func() { (&TotalOrderID{0, 1048576, 0}).ToInt64() }, ShouldPanic)
 		})
 
 		Convey("accomodates 32-bits of precision for the ledger", func() {
-			So(TotalOrderId{1, 0, 0}.ToInt64(), ShouldEqual, 4294967296)
-			So(TotalOrderId{math.MaxInt32, 0, 0}.ToInt64(), ShouldEqual, 9223372032559808512)
-			So(func() { TotalOrderId{-1, 0, 0}.ToInt64() }, ShouldPanic)
-			So(func() { TotalOrderId{math.MinInt32, 0, 0}.ToInt64() }, ShouldPanic)
+			So((&TotalOrderID{1, 0, 0}).ToInt64(), ShouldEqual, 4294967296)
+			So((&TotalOrderID{math.MaxInt32, 0, 0}).ToInt64(), ShouldEqual, 9223372032559808512)
+			So(func() { (&TotalOrderID{-1, 0, 0}).ToInt64() }, ShouldPanic)
+			So(func() { (&TotalOrderID{math.MinInt32, 0, 0}).ToInt64() }, ShouldPanic)
 		})
 
 		Convey("works as expected", func() {
-			So(TotalOrderId{1, 1, 1}.ToInt64(), ShouldEqual, ledger+tx+op)
-			So(TotalOrderId{1, 1, 0}.ToInt64(), ShouldEqual, ledger+tx)
-			So(TotalOrderId{1, 0, 1}.ToInt64(), ShouldEqual, ledger+op)
-			So(TotalOrderId{1, 0, 0}.ToInt64(), ShouldEqual, ledger)
-			So(TotalOrderId{0, 1, 0}.ToInt64(), ShouldEqual, tx)
-			So(TotalOrderId{0, 0, 1}.ToInt64(), ShouldEqual, op)
-			So(TotalOrderId{0, 0, 0}.ToInt64(), ShouldEqual, 0)
+			So((&TotalOrderID{1, 1, 1}).ToInt64(), ShouldEqual, ledger+tx+op)
+			So((&TotalOrderID{1, 1, 0}).ToInt64(), ShouldEqual, ledger+tx)
+			So((&TotalOrderID{1, 0, 1}).ToInt64(), ShouldEqual, ledger+op)
+			So((&TotalOrderID{1, 0, 0}).ToInt64(), ShouldEqual, ledger)
+			So((&TotalOrderID{0, 1, 0}).ToInt64(), ShouldEqual, tx)
+			So((&TotalOrderID{0, 0, 1}).ToInt64(), ShouldEqual, op)
+			So((&TotalOrderID{0, 0, 0}).ToInt64(), ShouldEqual, 0)
 		})
 	})
 
-	Convey("ParseTotalOrderId", t, func() {
-		toid := ParseTotalOrderId(ledger + tx + op)
+	Convey("ParseTotalOrderID", t, func() {
+		toid := ParseTotalOrderID(ledger + tx + op)
 		So(toid.LedgerSequence, ShouldEqual, 1)
 		So(toid.TransactionOrder, ShouldEqual, 1)
 		So(toid.OperationOrder, ShouldEqual, 1)
 
-		toid = ParseTotalOrderId(ledger + tx)
+		toid = ParseTotalOrderID(ledger + tx)
 		So(toid.LedgerSequence, ShouldEqual, 1)
 		So(toid.TransactionOrder, ShouldEqual, 1)
 		So(toid.OperationOrder, ShouldEqual, 0)
 
-		toid = ParseTotalOrderId(ledger + op)
+		toid = ParseTotalOrderID(ledger + op)
 		So(toid.LedgerSequence, ShouldEqual, 1)
 		So(toid.TransactionOrder, ShouldEqual, 0)
 		So(toid.OperationOrder, ShouldEqual, 1)
 
-		toid = ParseTotalOrderId(ledger)
+		toid = ParseTotalOrderID(ledger)
 		So(toid.LedgerSequence, ShouldEqual, 1)
 		So(toid.TransactionOrder, ShouldEqual, 0)
 		So(toid.OperationOrder, ShouldEqual, 0)
 
-		toid = ParseTotalOrderId(tx)
+		toid = ParseTotalOrderID(tx)
 		So(toid.LedgerSequence, ShouldEqual, 0)
 		So(toid.TransactionOrder, ShouldEqual, 1)
 		So(toid.OperationOrder, ShouldEqual, 0)
 
-		toid = ParseTotalOrderId(op)
+		toid = ParseTotalOrderID(op)
 		So(toid.LedgerSequence, ShouldEqual, 0)
 		So(toid.TransactionOrder, ShouldEqual, 0)
 		So(toid.OperationOrder, ShouldEqual, 1)
 	})
+
+	Convey("IncOperationOrder", t, func() {
+		tid := TotalOrderID{0, 0, 0}
+		tid.IncOperationOrder()
+		So(tid.OperationOrder, ShouldEqual, 1)
+		tid.OperationOrder = TotalOrderOperationMask
+		tid.IncOperationOrder()
+		So(tid.OperationOrder, ShouldEqual, 0)
+		So(tid.LedgerSequence, ShouldEqual, 1)
+	})
 }
 
-func ExampleParseTotalOrderId() {
-	toid := ParseTotalOrderId(12884910080)
+func ExampleParseTotalOrderID() {
+	toid := ParseTotalOrderID(12884910080)
 	fmt.Printf("ledger:%d, tx:%d, op:%d", toid.LedgerSequence, toid.TransactionOrder, toid.OperationOrder)
 	// Output: ledger:3, tx:2, op:0
 }

--- a/src/github.com/stellar/horizon/resource/main.go
+++ b/src/github.com/stellar/horizon/resource/main.go
@@ -58,7 +58,7 @@ type Balance struct {
 }
 
 // HistoryAccount is a simple resource, used for the account collection
-// actions.  It provides only the TotalOrderId of the account and its address.
+// actions.  It provides only the TotalOrderID of the account and its address.
 type HistoryAccount struct {
 	ID      string `json:"id"`
 	PT      string `json:"paging_token"`


### PR DESCRIPTION
The majority of this PR is delinting, but additionally I added `IncOperationOrder` to stop a panic from being triggered when querying for effects when the operation portion of a TotalOrderID was at the max value.  As an example, the path `/operations/3080685552144383/effects` would cause the bug fixed in this PR to be triggered
