### PR TITLE
Fix curl examples

### DIFF
--- a/docs/learn/tutorials/follow-received-payments.md
+++ b/docs/learn/tutorials/follow-received-payments.md
@@ -76,7 +76,7 @@ can use to get testnet lumens for testing purposes. To fund your account, simply
 execute the following curl command:
 
 ```bash
-$ curl https://horizon-testnet.stellar.org/friendbot?addr=GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3
+$ curl "https://horizon-testnet.stellar.org/friendbot?addr=GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3"
 ```
 
 Don't forget to replace the address above with your own.  If the request
@@ -100,7 +100,7 @@ terminal.
 To follow new payments connected to your account you simply need to send `Accept: text/event-stream` header to the [/payments](../../reference/payments-all.md) endpoint.
 
 ```bash
-$ curl -H 'Accept: text/event-stream' https://horizon-testnet.stellar.org/accounts/GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3/payments
+$ curl -H "Accept: text/event-stream" "https://horizon-testnet.stellar.org/accounts/GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3/payments"
 ```
 
 As a result you will see something like:
@@ -170,7 +170,7 @@ We now know how to get a stream of transactions to an account. Let's check if ou
 First, let's check our account sequence number so we can create a payment operation. To do this we send a request to horizon:
 
 ```bash
-$ curl https://horizon-testnet.stellar.org/accounts/GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3
+$ curl "https://horizon-testnet.stellar.org/accounts/GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3"
 ```
 
 Sequence number can be found under the `sequence` field. The current sequence number is `713226564141056`. Save this value somewhere.
@@ -202,7 +202,7 @@ After running this script you should see a signed transaction blob. To submit th
 Now to send a transaction just use horizon:
 
 ```bash
-curl -H "Content-Type: application/json" -X POST -d '{"tx":"AAAAAH6Sq76F4cHVMWvGG4AtNtFVIvayUxSgR401rPY9ej3TAAAD6AACiK0AAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAKc1j3y10+nI+sxuXlmFz71JS35mp/RcPCP45Gw0obdAAAAAAAAAAAAExLQAAAAAAAAAAAT16PdMAAABAsJTBC5N5B9Q/9+ZKS7qkMd/wZHWlP6uCCFLzeD+JWT60/VgGFCpzQhZmMg2k4Vg+AwKJTwko3d7Jt3Y6WhjLCg=="}' https://horizon-testnet.stellar.org/transactions
+curl -H "Content-Type: application/json" -X POST -d '{"tx":"AAAAAH6Sq76F4cHVMWvGG4AtNtFVIvayUxSgR401rPY9ej3TAAAD6AACiK0AAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAKc1j3y10+nI+sxuXlmFz71JS35mp/RcPCP45Gw0obdAAAAAAAAAAAAExLQAAAAAAAAAAAT16PdMAAABAsJTBC5N5B9Q/9+ZKS7qkMd/wZHWlP6uCCFLzeD+JWT60/VgGFCpzQhZmMg2k4Vg+AwKJTwko3d7Jt3Y6WhjLCg=="}' "https://horizon-testnet.stellar.org/transactions"
 ```
 
 You should see a new payment in a window running `stream_payments.js` script.

--- a/docs/reference/accounts-all.md
+++ b/docs/reference/accounts-all.md
@@ -25,7 +25,7 @@ GET /accounts{?cursor,limit,order}
 ### curl Example Request
 
 ```shell
-curl https://horizon-testnet.stellar.org/transactions?limit=200&order=desc
+curl "https://horizon-testnet.stellar.org/transactions?limit=200&order=desc"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/accounts-single.md
+++ b/docs/reference/accounts-single.md
@@ -21,7 +21,7 @@ GET /accounts/{account}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ
+curl "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/effects-all.md
+++ b/docs/reference/effects-all.md
@@ -24,7 +24,7 @@ GET /effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/effects
+curl "https://horizon-testnet.stellar.org/effects"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/effects-for-account.md
+++ b/docs/reference/effects-for-account.md
@@ -25,7 +25,7 @@ GET /accounts/{account}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects
+curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/effects-for-ledger.md
+++ b/docs/reference/effects-for-ledger.md
@@ -24,7 +24,7 @@ GET /ledgers/{id}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/ledgers/69859/effects
+curl "https://horizon-testnet.stellar.org/ledgers/69859/effects"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/effects-for-operation.md
+++ b/docs/reference/effects-for-operation.md
@@ -22,7 +22,7 @@ GET /operations/{id}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/operations/77309415424/effects
+curl "https://horizon-testnet.stellar.org/operations/77309415424/effects"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/effects-for-transaction.md
+++ b/docs/reference/effects-for-transaction.md
@@ -22,7 +22,7 @@ GET /transactions/{hash}/effects{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/effects
+curl "https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/effects"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/errors/not-acceptable.md
+++ b/docs/reference/errors/not-acceptable.md
@@ -24,7 +24,7 @@ As with all errors Horizon returns, `not_acceptable` follows the [Problem Detail
 ## Example
 
 ```bash
-$ curl -X GET -H "Accept: application/xml" 'https://horizon-testnet.stellar.org/accounts/GALWEV6GY73RJ255JC7XUOZ2L7WZ5JJDTKATB2MUK7F3S67DVT2A6R5G'
+$ curl -X GET -H "Accept: application/xml" "https://horizon-testnet.stellar.org/accounts/GALWEV6GY73RJ255JC7XUOZ2L7WZ5JJDTKATB2MUK7F3S67DVT2A6R5G"
 {
   "type": "not_acceptable",
   "title": "An acceptable response content-type could not be provided for this request",

--- a/docs/reference/errors/not-found.md
+++ b/docs/reference/errors/not-found.md
@@ -21,7 +21,7 @@ As with all errors Horizon returns, `not_found` follows the [Problem Details for
 ## Example
 
 ```shell
-$ curl -X GET 'https://horizon-testnet.stellar.org/accounts/accountthatdoesntexist'
+$ curl -X GET "https://horizon-testnet.stellar.org/accounts/accountthatdoesntexist"
 {
   "type": "not_found",
   "title": "Resource Missing",

--- a/docs/reference/errors/not-implemented.md
+++ b/docs/reference/errors/not-implemented.md
@@ -22,7 +22,7 @@ As with all errors Horizon returns, `not_implemented` follows the [Problem Detai
 ## Examples
 
 ```shell
-$ curl -X GET 'https://horizon-testnet.stellar.org/ledgers/:200/effects'
+$ curl -X GET "https://horizon-testnet.stellar.org/ledgers/200/effects"
 {
   "type": "not_implemented",
   "title": "Resource Not Yet Implemented",

--- a/docs/reference/ledgers-all.md
+++ b/docs/reference/ledgers-all.md
@@ -24,7 +24,7 @@ GET /ledgers{?cursor,limit,order}
 
 ```sh
 # Retrieve the 200 latest ledgers, ordered chronologically
-curl https://horizon-testnet.stellar.org/ledgers?limit=200&order=desc
+curl "https://horizon-testnet.stellar.org/ledgers?limit=200&order=desc"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/ledgers-single.md
+++ b/docs/reference/ledgers-single.md
@@ -19,7 +19,7 @@ GET /ledgers/{id}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/ledgers/69859
+curl "https://horizon-testnet.stellar.org/ledgers/69859"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/offers-for-account.md
+++ b/docs/reference/offers-for-account.md
@@ -23,7 +23,7 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/offers
+curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/offers"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/operations-all.md
+++ b/docs/reference/operations-all.md
@@ -23,7 +23,7 @@ GET /operations{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/operations?limit=200&order=desc
+curl "https://horizon-testnet.stellar.org/operations?limit=200&order=desc"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/operations-for-account.md
+++ b/docs/reference/operations-for-account.md
@@ -25,7 +25,7 @@ GET /accounts/{account}/operations{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/operations
+curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/operations"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/operations-for-ledger.md
+++ b/docs/reference/operations-for-ledger.md
@@ -22,7 +22,7 @@ GET /ledgers/{id}/operations{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/ledgers/69859/operations
+curl "https://horizon-testnet.stellar.org/ledgers/69859/operations"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/operations-for-transaction.md
+++ b/docs/reference/operations-for-transaction.md
@@ -22,7 +22,7 @@ GET /transactions/{hash}/operations{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/operations
+curl "https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a/operations"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/orderbook-details.md
+++ b/docs/reference/orderbook-details.md
@@ -29,7 +29,7 @@ GET /orderbook?selling_asset_type={selling_asset_type}&selling_asset_code={selli
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4
+curl "https://horizon-testnet.stellar.org/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
 ```
 ### JavaScript Example Request
 

--- a/docs/reference/path-finding.md
+++ b/docs/reference/path-finding.md
@@ -35,7 +35,7 @@ GET /paths?destination_account={da}&source_account={sa}&destination_asset_type={
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/paths?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&destination_amount=20
+curl "https://horizon-testnet.stellar.org/paths?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&destination_amount=20"
 ```
 
 ## Response

--- a/docs/reference/payments-all.md
+++ b/docs/reference/payments-all.md
@@ -23,13 +23,13 @@ GET /payments{?cursor,limit,order}
 
 ```bash
 # Retrieve the first 200 payments, ordered chronologically.
-curl https://horizon-testnet.stellar.org/payments?limit=200
+curl "https://horizon-testnet.stellar.org/payments?limit=200"
 ```
 
 ```bash
 # Retrieve a page of payments to occur immediately before the transaction
 # specified by the paging token "1234".
-curl https://horizon-testnet.stellar.org/payments?cursor=1234&order=desc
+curl "https://horizon-testnet.stellar.org/payments?cursor=1234&order=desc"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/payments-for-account.md
+++ b/docs/reference/payments-for-account.md
@@ -26,7 +26,7 @@ GET /accounts/{id}/payments{?cursor,limit,order}
 
 ```bash
 # Retrieve the 25 latest payments for a specific account.
-curl https://horizon-testnet.stellar.org/account/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/payments?limit=25&order=desc
+curl "https://horizon-testnet.stellar.org/account/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/payments?limit=25&order=desc"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/payments-for-ledger.md
+++ b/docs/reference/payments-for-ledger.md
@@ -22,7 +22,7 @@ GET /ledgers/{id}/payments{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/ledgers/69859/payments
+curl "https://horizon-testnet.stellar.org/ledgers/69859/payments"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/payments-for-transaction.md
+++ b/docs/reference/payments-for-transaction.md
@@ -22,7 +22,7 @@ GET /transactions/{hash}/payments{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/transactions/3c8ef808df9d5d240ba0d495629df9da5653b1be2daf05d43b49c5bcbfe099bd/payments
+curl "https://horizon-testnet.stellar.org/transactions/3c8ef808df9d5d240ba0d495629df9da5653b1be2daf05d43b49c5bcbfe099bd/payments"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/trades-for-orderbook.md
+++ b/docs/reference/trades-for-orderbook.md
@@ -29,7 +29,7 @@ GET /orderbook/trades?selling_asset_type={selling_asset_type}&selling_asset_code
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/order_book/trades?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4
+curl "https://horizon-testnet.stellar.org/order_book/trades?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/transactions-all.md
+++ b/docs/reference/transactions-all.md
@@ -25,7 +25,7 @@ GET /transactions{?cursor,limit,order}
 
 ```sh
 # Retrieve the 200 latest transactions, ordered chronologically:
-curl https://horizon-testnet.stellar.org/transactions?limit=200&order=desc
+curl "https://horizon-testnet.stellar.org/transactions?limit=200&order=desc"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/transactions-create.md
+++ b/docs/reference/transactions-create.md
@@ -42,7 +42,7 @@ POST /transactions
 ```sh
 curl -X POST \
      -F "tx=AAAAAOo1QK/3upA74NLkdq4Io3DQAQZPi4TVhuDnvCYQTKIVAAAACgAAH8AAAAABAAAAAAAAAAAAAAABAAAAAQAAAADqNUCv97qQO+DS5HauCKNw0AEGT4uE1Ybg57wmEEyiFQAAAAEAAAAAZc2EuuEa2W1PAKmaqVquHuzUMHaEiRs//+ODOfgWiz8AAAAAAAAAAAAAA+gAAAAAAAAAARBMohUAAABAPnnZL8uPlS+c/AM02r4EbxnZuXmP6pQHvSGmxdOb0SzyfDB2jUKjDtL+NC7zcMIyw4NjTa9Ebp4lvONEf4yDBA==" \
-  https://horizon-testnet.stellar.org/transactions
+  "https://horizon-testnet.stellar.org/transactions"
 ```
 
 ## Response

--- a/docs/reference/transactions-for-account.md
+++ b/docs/reference/transactions-for-account.md
@@ -24,7 +24,7 @@ GET /accounts/{address}/transactions{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/transactions?limit=1
+curl "https://horizon-testnet.stellar.org/accounts/GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ/transactions?limit=1"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/transactions-for-ledger.md
+++ b/docs/reference/transactions-for-ledger.md
@@ -22,7 +22,7 @@ GET /ledgers/{id}/transactions{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/ledgers/69859/transactions
+curl "https://horizon-testnet.stellar.org/ledgers/69859/transactions"
 ```
 
 ### JavaScript Example Request

--- a/docs/reference/transactions-single.md
+++ b/docs/reference/transactions-single.md
@@ -19,7 +19,7 @@ GET /transactions/{hash}
 ### curl Example Request
 
 ```sh
-curl https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a
+curl "https://horizon-testnet.stellar.org/transactions/6391dd190f15f7d1665ba53c63842e368f485651a53d8d852ed442a446d1c69a"
 ```
 
 ### JavaScript Example Request


### PR DESCRIPTION
Some curl examples contain `&` which starts a background process on some systems. Added quotes to urls.
