### PR TITLE
Add Base#Setup(), use it for LoadQuery on SSE responses

### DIFF
--- a/src/github.com/stellar/horizon/actions/base.go
+++ b/src/github.com/stellar/horizon/actions/base.go
@@ -22,6 +22,8 @@ type Base struct {
 	W       http.ResponseWriter
 	R       *http.Request
 	Err     error
+
+	isSetup bool
 }
 
 // Prepare established the common attributes that get used in nearly every
@@ -94,8 +96,9 @@ NotAcceptable:
 	return
 }
 
-// Do executes the provided func iff there is no current error for the action. Provides
-// a nicer way to invoke a set of steps that each may set `action.Err` during execution
+// Do executes the provided func iff there is no current error for the action.
+// Provides a nicer way to invoke a set of steps that each may set `action.Err`
+// during execution
 func (base *Base) Do(fns ...func()) {
 	for _, fn := range fns {
 		if base.Err != nil {
@@ -104,4 +107,14 @@ func (base *Base) Do(fns ...func()) {
 
 		fn()
 	}
+}
+
+// Setup runs the provided funcs if and only if no call to Setup() has been
+// made previously on this action.
+func (base *Base) Setup(fns ...func()) {
+	if base.isSetup {
+		return
+	}
+	base.Do(fns...)
+	base.isSetup = true
 }

--- a/src/github.com/stellar/horizon/actions_account.go
+++ b/src/github.com/stellar/horizon/actions_account.go
@@ -62,9 +62,8 @@ func (action *AccountIndexAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *AccountIndexAction) SSE(stream sse.Stream) {
-
+	action.Setup(action.LoadQuery)
 	action.Do(
-		action.LoadQuery,
 		action.LoadRecords,
 		func() {
 			stream.SetLimit(int(action.Query.Limit))

--- a/src/github.com/stellar/horizon/actions_effects.go
+++ b/src/github.com/stellar/horizon/actions_effects.go
@@ -34,8 +34,9 @@ func (action *EffectIndexAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *EffectIndexAction) SSE(stream sse.Stream) {
+	action.Setup(action.LoadQuery)
+
 	action.Do(
-		action.LoadQuery,
 		action.LoadRecords,
 		func() {
 			stream.SetLimit(int(action.Query.Limit))

--- a/src/github.com/stellar/horizon/actions_ledger.go
+++ b/src/github.com/stellar/horizon/actions_ledger.go
@@ -33,8 +33,8 @@ func (action *LedgerIndexAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *LedgerIndexAction) SSE(stream sse.Stream) {
+	action.Setup(action.LoadQuery)
 	action.Do(
-		action.LoadQuery,
 		action.LoadRecords,
 		func() {
 			stream.SetLimit(int(action.Query.Limit))

--- a/src/github.com/stellar/horizon/actions_transaction.go
+++ b/src/github.com/stellar/horizon/actions_transaction.go
@@ -71,8 +71,8 @@ func (action *TransactionIndexAction) JSON() {
 
 // SSE is a method for actions.SSE
 func (action *TransactionIndexAction) SSE(stream sse.Stream) {
+	action.Setup(action.LoadQuery)
 	action.Do(
-		action.LoadQuery,
 		action.LoadRecords,
 		func() {
 			stream.SetLimit(int(action.Query.Limit))


### PR DESCRIPTION
Fixes a panic triggered when using the cursor “now” on streaming actions
