### PR TITLE
fix example response titles to be properly formatted

### DIFF
--- a/docs/reference/path-finding.md
+++ b/docs/reference/path-finding.md
@@ -42,7 +42,7 @@ curl "https://horizon-testnet.stellar.org/paths?destination_account=GAEDTJ4PPEFV
 
 This endpoint responds with a page of path resources.  See [path resource](./resources/path.md) for reference.
 
-### Example Response:
+### Example Response
 
 ```json
 {


### PR DESCRIPTION
There must be a `## Example Response` for the developers site to properly show the titles.
