### PR TITLE
Replace "Address" with "Account ID" or "Public key" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ bumps.  A breaking change will get clearly notified in this log.
 
 ## [Unreleased]
 
+### Changes
+
+- BREAKING CHANGE: the `address` field of a signer in the account resource has been renamed to `public_key`.
+- BREAKING CHANGE: the `address` on the account resource has been renamed to `account_id`.
+
 ## [v0.1.1] - 2015-12-01
 
 ### Added

--- a/docs/learn/tutorials/follow-received-payments.md
+++ b/docs/learn/tutorials/follow-received-payments.md
@@ -79,7 +79,7 @@ execute the following curl command:
 $ curl "https://horizon-testnet.stellar.org/friendbot?addr=GB7JFK56QXQ4DVJRNPDBXABNG3IVKIXWWJJRJICHRU22Z5R5PI65GAK3"
 ```
 
-Don't forget to replace the address above with your own.  If the request
+Don't forget to replace the account id above with your own.  If the request
 succeeds, you should see a response like:
 
 ```json

--- a/docs/reference/accounts-all.md
+++ b/docs/reference/accounts-all.md
@@ -3,7 +3,7 @@ title: All Accounts
 ---
 
 The all accounts endpoint returns a collection of all the [accounts](./resources/account.md) that have ever existed. Results
-are ordered by account creation time. An address may show up multiple times if they were [merged](./resources/operation.md#Account_Merge) and then [created](./resources/operation.md#Create_Account) again.
+are ordered by account creation time. An account id may show up multiple times if they were [merged](./resources/operation.md#Account_Merge) and then [created](./resources/operation.md#Create_Account) again.
 
 This endpoint can also be used in [streaming](../learn/responses.md#streaming) mode so it is possible to use it to listen for new accounts as they get made in the Stellar network.
 If called in streaming mode Horizon will start at the earliest known account unless a `cursor` is set. In that case it will start from the `cursor`. You can also set `cursor` value to `now` to only stream accounts created since your request time.
@@ -66,52 +66,52 @@ See [accounts](./resources/account.md) for reference.
       {
         "id": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO",
         "paging_token": "77309415424",
-        "address": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO"
+        "account_id": "GBIA4FH6TV64KSPDAJCNUQSM7PFL4ILGUVJDPCLUOPJ7ONMKBBVUQHRO"
       },
       {
         "id": "GC2ADYAIPKYQRGGUFYBV2ODJ54PY6VZUPKNCWWNX2C7FCJYKU4ZZNKVL",
         "paging_token": "463856472064",
-        "address": "GC2ADYAIPKYQRGGUFYBV2ODJ54PY6VZUPKNCWWNX2C7FCJYKU4ZZNKVL"
+        "account_id": "GC2ADYAIPKYQRGGUFYBV2ODJ54PY6VZUPKNCWWNX2C7FCJYKU4ZZNKVL"
       },
       {
         "id": "GB4ZONAMYWRCU7KPV6A6DEPIY3YDZFVFTFC42XQGLWJQ53GQEDE3TI4C",
         "paging_token": "605590392832",
-        "address": "GB4ZONAMYWRCU7KPV6A6DEPIY3YDZFVFTFC42XQGLWJQ53GQEDE3TI4C"
+        "account_id": "GB4ZONAMYWRCU7KPV6A6DEPIY3YDZFVFTFC42XQGLWJQ53GQEDE3TI4C"
       },
       {
         "id": "GBC6OK4WVUKWUTHNJLKLYJ57G6UUQTJMHY2ON6R4DMRRCRDKYAWGH6CY",
         "paging_token": "31490700218368",
-        "address": "GBC6OK4WVUKWUTHNJLKLYJ57G6UUQTJMHY2ON6R4DMRRCRDKYAWGH6CY"
+        "account_id": "GBC6OK4WVUKWUTHNJLKLYJ57G6UUQTJMHY2ON6R4DMRRCRDKYAWGH6CY"
       },
       {
         "id": "GC5BIFJBP5GTNYB3WHM7MA7J3Z2EF7VE7XCDU7V47AOZMGIBB4324W63",
         "paging_token": "35631048691712",
-        "address": "GC5BIFJBP5GTNYB3WHM7MA7J3Z2EF7VE7XCDU7V47AOZMGIBB4324W63"
+        "account_id": "GC5BIFJBP5GTNYB3WHM7MA7J3Z2EF7VE7XCDU7V47AOZMGIBB4324W63"
       },
       {
         "id": "GD7IDKHPOQJ2DFICCBSX5QEDSXSC5U7HRZLKNIXGCLDRRU5UOBEYABJO",
         "paging_token": "35927401435136",
-        "address": "GD7IDKHPOQJ2DFICCBSX5QEDSXSC5U7HRZLKNIXGCLDRRU5UOBEYABJO"
+        "account_id": "GD7IDKHPOQJ2DFICCBSX5QEDSXSC5U7HRZLKNIXGCLDRRU5UOBEYABJO"
       },
       {
         "id": "GBSN5O2Q47RDWKANTBK5PZAOMHMQQZE53LS32OKCBY6XGXZSFAVD7SUR",
         "paging_token": "46269682683904",
-        "address": "GBSN5O2Q47RDWKANTBK5PZAOMHMQQZE53LS32OKCBY6XGXZSFAVD7SUR"
+        "account_id": "GBSN5O2Q47RDWKANTBK5PZAOMHMQQZE53LS32OKCBY6XGXZSFAVD7SUR"
       },
       {
         "id": "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB",
         "paging_token": "46316927324160",
-        "address": "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB"
+        "account_id": "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB"
       },
       {
         "id": "GAKLBGHNHFQ3BMUYG5KU4BEWO6EYQHZHAXEWC33W34PH2RBHZDSQBD75",
         "paging_token": "46428596473856",
-        "address": "GAKLBGHNHFQ3BMUYG5KU4BEWO6EYQHZHAXEWC33W34PH2RBHZDSQBD75"
+        "account_id": "GAKLBGHNHFQ3BMUYG5KU4BEWO6EYQHZHAXEWC33W34PH2RBHZDSQBD75"
       },
       {
         "id": "GBAP36MOHWTXNGO6I6UYUXSOF7AA2PA5Y26PJW6VG7CVDFQPIX243ILV",
         "paging_token": "46669114642432",
-        "address": "GBAP36MOHWTXNGO6I6UYUXSOF7AA2PA5Y26PJW6VG7CVDFQPIX243ILV"
+        "account_id": "GBAP36MOHWTXNGO6I6UYUXSOF7AA2PA5Y26PJW6VG7CVDFQPIX243ILV"
       }
     ]
   },
@@ -156,7 +156,7 @@ See [accounts](./resources/account.md) for reference.
   },
   "id": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
   "paging_token": "66035122180096",
-  "address": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
+  "account_id": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
   "sequence": 66035122176002,
   "balances": [
     {
@@ -170,5 +170,3 @@ See [accounts](./resources/account.md) for reference.
 ## errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-
-

--- a/docs/reference/accounts-single.md
+++ b/docs/reference/accounts-single.md
@@ -4,7 +4,7 @@ title: Account Details
 
 Returns information and links relating to a single [account](./resources/account.md).
 
-The balances section in the returned JSON will also list all the [trust lines](https://www.stellar.org/developers/learn/concepts/assets.html) this account has set up. 
+The balances section in the returned JSON will also list all the [trust lines](https://www.stellar.org/developers/learn/concepts/assets.html) this account has set up.
 
 ## Request
 
@@ -16,7 +16,7 @@ GET /accounts/{account}
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `account` | required, string | Account address | GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36 |
+| `account` | required, string | Account ID | GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36 |
 
 ### curl Example Request
 
@@ -43,7 +43,7 @@ server.accounts()
 
 ## Response
 
-This endpoint responds with the details of a single account for a given address. See [account resource](./resources/account.md) for reference.
+This endpoint responds with the details of a single account for a given ID. See [account resource](./resources/account.md) for reference.
 
 ### Example Response
 ```json
@@ -71,7 +71,7 @@ This endpoint responds with the details of a single account for a given address.
   },
   "id": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
   "paging_token": "66035122180096",
-  "address": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
+  "account_id": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
   "sequence": 66035122176002,
   "balances": [
     {
@@ -85,4 +85,4 @@ This endpoint responds with the details of a single account for a given address.
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard-Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `account` argument.

--- a/docs/reference/effects-for-account.md
+++ b/docs/reference/effects-for-account.md
@@ -17,7 +17,7 @@ GET /accounts/{account}/effects{?cursor,limit,order}
 
 |  name  |  notes  | description | example |
 | ------ | ------- | ----------- | ------- |
-| `account` | required, string | Account address | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
+| `account` | required, string | Account ID | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
 | `?cursor` | optional, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc".               | `asc`         |
 | `?limit`  | optional, number, default `10` | Maximum number of records to return. | `200` |
@@ -114,4 +114,3 @@ The list of effects.
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
 - [not_found](./errors/not-found.md): A `not_found` error will be returned if there are no effects for the given account.
-

--- a/docs/reference/offers-for-account.md
+++ b/docs/reference/offers-for-account.md
@@ -15,7 +15,7 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `account` | required, string | Account address | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
+| `account` | required, string | Account ID | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |

--- a/docs/reference/operations-for-account.md
+++ b/docs/reference/operations-for-account.md
@@ -17,7 +17,7 @@ GET /accounts/{account}/operations{?cursor,limit,order}
 
 | name     | notes                          | description                                                      | example                                                   |
 | ------   | -------                        | -----------                                                      | -------                                                   |
-| `account`| required, string               | Account address                                                  | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36`|
+| `account`| required, string               | Account ID                                                  | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36`|
 | `?cursor`| optional, default _null_       | A paging token, specifying where to start returning records from.| `12884905984`                                             |
 | `?order` | optional, string, default `asc`| The order in which to return rows, "asc" or "desc".              | `asc`                                                     |
 | `?limit` | optional, number, default `10` | Maximum number of records to return.                             | `200`                                                     |
@@ -134,4 +134,4 @@ This endpoint responds with a list of operations that affected the given account
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `account` argument.

--- a/docs/reference/operations-for-ledger.md
+++ b/docs/reference/operations-for-ledger.md
@@ -98,4 +98,4 @@ This endpoint responds with a list of operations in a given ledger.  See [operat
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no ledger whose ID matches the `id` argument.

--- a/docs/reference/operations-for-transaction.md
+++ b/docs/reference/operations-for-transaction.md
@@ -98,4 +98,4 @@ This endpoint responds with a list of operations that are part of a given transa
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `hash` argument.

--- a/docs/reference/operations-single.md
+++ b/docs/reference/operations-single.md
@@ -80,4 +80,4 @@ This endpoint responds with a single Operation.  See [operation resource](./reso
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no  whose ID matches the `account` argument.

--- a/docs/reference/orderbook-details.md
+++ b/docs/reference/orderbook-details.md
@@ -18,10 +18,10 @@ GET /order_book?selling_asset_type={selling_asset_type}&selling_asset_code={sell
 | ---- | ----- | ----------- | ------- |
 | `selling_asset_type` | required, string | Type of the Asset being sold | `native` |
 | `selling_asset_code` | optional, string | Code of the Asset being sold | `USD` |
-| `selling_asset_issuer` | optional, string | Address of the issuer of the Asset being sold | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
+| `selling_asset_issuer` | optional, string | Account ID of the issuer of the Asset being sold | `GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36` |
 | `buying_asset_type` | required, string | Type of the Asset being bought | `credit_alphanum4` |
 | `buying_asset_code` | optional, string | Code of the Asset being bought | `BTC` |
-| `buying_asset_issuer` | optional, string | Address of the issuer of the Asset being bought | `GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z` |
+| `buying_asset_issuer` | optional, string | Account ID of the issuer of the Asset being bought | `GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z` |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |

--- a/docs/reference/path-finding.md
+++ b/docs/reference/path-finding.md
@@ -7,11 +7,11 @@ The Stellar Network allows payments to be made across assets through _path payme
 
 A path search is specified using:
 
-- The destination address
-- The source address
+- The destination account id
+- The source account id
 - The asset and amount that the destination account should receive
 
-As part of the search, horizon will load a list of assets available to the source address and will find any payment paths from those source assets to the desired destination asset. The search's amount parameter will be used to determine if there a given path can satisfy a payment of the desired amount.
+As part of the search, horizon will load a list of assets available to the source account id and will find any payment paths from those source assets to the desired destination asset. The search's amount parameter will be used to determine if there a given path can satisfy a payment of the desired amount.
 
 ## Request
 
@@ -23,12 +23,12 @@ GET /paths?destination_account={da}&source_account={sa}&destination_asset_type={
 
 | name                        | notes  | description                                                                                        | example                                                    |
 |-----------------------------|--------|----------------------------------------------------------------------------------------------------|------------------------------------------------------------|
-| `?destination_account`      | string | The destination address that any returned path should use                                          | `GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V` |
+| `?destination_account`      | string | The destination account that any returned path should use                                          | `GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V` |
 | `?destination_asset_type`   | string | The type of the destination asset                                                                  | `credit_alphanum4`                                         |
 | `?destination_asset_code`   | string | The code for the destination, if destination_asset_type is not "native"                            | `GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V` |
 | `?destination_asset_issuer` | string | The issuer for the destination, if destination_asset_type is not "native"                          | `GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V` |
 | `?destination_amount`       | string | The amount, denominated in the destination asset, that any returned path should be able to satisfy | `10.1`                                                     |
-| `?source_account`           | string | The sender's address.  Any returned path must use a source that the sender can hold                | `GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP` |
+| `?source_account`           | string | The sender's account id.  Any returned path must use a source that the sender can hold                | `GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP` |
 
 
 

--- a/docs/reference/payments-for-account.md
+++ b/docs/reference/payments-for-account.md
@@ -17,7 +17,7 @@ GET /accounts/{id}/payments{?cursor,limit,order}
 
 |  name  |  notes  | description | example |
 | ------ | ------- | ----------- | ------- |
-| `id`      | required, string | The address of the account used to constrain results. | `GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ` |
+| `id`      | required, string | The account id of the account used to constrain results. | `GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ` |
 | `?cursor` | optional, default _null_ | A payment paging token specifying from where to begin results. | `8589934592`                                          |
 | `?limit`  | optional, number, default `10`  | Specifies the count of records at most to return. | `200` |
 | `?order` | optional, string, default `asc` | Specifies order of returned results. `asc` means older payments first, `desc` mean newer payments first. | `desc` |

--- a/docs/reference/payments-for-ledger.md
+++ b/docs/reference/payments-for-ledger.md
@@ -98,4 +98,4 @@ This endpoint responds with a list of payment operations in a given ledger.  See
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no ledger whose ID matches the `id` argument.

--- a/docs/reference/payments-for-transaction.md
+++ b/docs/reference/payments-for-transaction.md
@@ -96,4 +96,4 @@ This endpoint responds with a list of payments operations that are part of a giv
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no transaction whose ID matches the `hash` argument.

--- a/docs/reference/payments-for-transaction.md
+++ b/docs/reference/payments-for-transaction.md
@@ -91,7 +91,10 @@ This endpoint responds with a list of payments operations that are part of a giv
       "href": "?order=asc&limit=10&cursor="
     }
   }
+}
 ```
+
+
 
 ## Possible Errors
 

--- a/docs/reference/resources/account.md
+++ b/docs/reference/resources/account.md
@@ -13,7 +13,7 @@ When horizon returns information about an account it uses the following format:
 |--------------|------------------|------------------------------------------------------------------------------------------------------------------------|
 | id           | string           | The canonical id of this account, suitable for use as the :id parameter for url templates that require an account's ID. |
 | paging_token | number           | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                                |
-| address      | string           | The account' public key encoded into a base32 string representation.                                                    |
+| account_id      | string           | The account's public key encoded into a base32 string representation.                                                    |
 | sequence     | number           | The current sequence number that can be used when submitting a transaction from this account.                           |
 | balances     | array of objects | An array of the native asset or credits this account holds.                                                          |
 
@@ -53,7 +53,7 @@ When horizon returns information about an account it uses the following format:
   },
   "id": "GAOEWNUEKXKNGB2AAOX6S6FEP6QKCFTU7KJH647XTXQXTMOAUATX2VF5",
   "paging_token": "132564165595136",
-  "address": "GAOEWNUEKXKNGB2AAOX6S6FEP6QKCFTU7KJH647XTXQXTMOAUATX2VF5",
+  "account_id": "GAOEWNUEKXKNGB2AAOX6S6FEP6QKCFTU7KJH647XTXQXTMOAUATX2VF5",
   "sequence": 132564165591040,
   "balances": [
     {

--- a/docs/reference/resources/offer.md
+++ b/docs/reference/resources/offer.md
@@ -11,7 +11,7 @@ Horizon only returns offers that belong to a particular account.  When it does, 
 |--------------|------------------|------------------------------------------------------------------------------------------------------------------------|
 | id           | integer           | The ID of this offer. |
 | paging_token | string           | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                                |
-| seller      | string           | Address of the account making this offer.                                                    |
+| seller      | string           | Account id of the account making this offer.                                                    |
 | selling     | [Asset](http://stellar.org/developers/learn/concepts/assets.html)           | The Asset this offer wants to sell.                      |
 | buying     | [Asset](http://stellar.org/developers/learn/concepts/assets.html) | The Asset this offer wants to buy. |
 | amount | string | The amount of `selling` the account making this offer is willing to sell.|

--- a/docs/reference/resources/operation.md
+++ b/docs/reference/resources/operation.md
@@ -354,7 +354,7 @@ Use “Set Options” operation to set following options to your account:
 
 | Field           |  Type  | Description       |
 | --------------- | ------ | ----------------- |
-| signer_key | string | The address of the new signer. |
+| signer_key | string | The public key of the new signer. |
 | signer_weight | int | The weight of the new signer (1-255). |
 | master_key_weight | int | The weight of the master key (1-255). |
 | low_threshold | int | The sum weight for the low threshold. |
@@ -519,7 +519,7 @@ Removes the account and transfers all remaining XLM to the destination account.
 
 | Field           |  Type  | Description       |
 | --------------- | ------ | ----------------- |
-| into | string | Address where funds of deleted account were transferred. |
+| into | string | Account ID where funds of deleted account were transferred. |
 
 #### Example
 ```json
@@ -594,4 +594,3 @@ Runs inflation.
 | [Ledger Operations](../operations-for-ledger.md)   | Collection | `/ledgers/{id}/operations{?cursor,limit,order}` |
 | [Account Operations](../operations-for-account.md) | Collection | `/accounts/:account_id/operations` |
 | [Account Payments](../payments-for-account.md)     | Collection | `/accounts/:account_id/payments` |
-

--- a/docs/reference/trades-for-orderbook.md
+++ b/docs/reference/trades-for-orderbook.md
@@ -18,10 +18,10 @@ GET /order_book/trades?selling_asset_type={selling_asset_type}&selling_asset_cod
 | ---- | ----- | ----------- | ------- |
 | `selling_asset_type` | required, string | Type of the Asset being sold | `native` |
 | `selling_asset_code` | optional, string | Code of the Asset being sold | `USD` |
-| `selling_asset_issuer` | optional, string | Address of the issuer of the Asset being sold | 'GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36' |
+| `selling_asset_issuer` | optional, string | Account ID of the issuer of the Asset being sold | 'GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36' |
 | `buying_asset_type` | required, string | Type of the Asset being bought | `credit_alphanum4` |
 | `buying_asset_code` | optional, string | Code of the Asset being bought | `BTC` |
-| `buying_asset_issuer` | optional, string | Address of the issuer of the Asset being bought | 'GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z' |
+| `buying_asset_issuer` | optional, string | Account ID of the issuer of the Asset being bought | 'GD6VWBXI6NY3AOOR55RLVQ4MNIDSXE5JSAVXUTF35FRRI72LYPI3WL6Z' |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | `12884905984` |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |

--- a/docs/reference/transactions-for-account.md
+++ b/docs/reference/transactions-for-account.md
@@ -9,14 +9,14 @@ If called in streaming mode Horizon will start at the earliest known transaction
 ## Request
 
 ```
-GET /accounts/{address}/transactions{?cursor,limit,order}
+GET /accounts/{account_id}/transactions{?cursor,limit,order}
 ```
 
 ### Arguments
 
 | name | notes | description | example |
 | ---- | ----- | ----------- | ------- |
-| `address` | required, string | Address of an account | GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ |
+| `account_id` | required, string | ID of an account | GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ |
 | `?cursor` | optional, any, default _null_ | A paging token, specifying where to start returning records from. | 12884905984 |
 | `?order`  | optional, string, default `asc` | The order in which to return rows, "asc" or "desc". | `asc` |
 | `?limit`  | optional, number, default: `10` | Maximum number of records to return. | `200` |
@@ -178,4 +178,4 @@ This endpoint responds with a list of transactions that changed a given account'
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `account_id` argument.

--- a/docs/reference/transactions-for-ledger.md
+++ b/docs/reference/transactions-for-ledger.md
@@ -113,4 +113,4 @@ This endpoint responds with a list of transactions in a given ledger.  See [tran
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no ledgers whose sequence matches the `id` argument.

--- a/docs/reference/transactions-single.md
+++ b/docs/reference/transactions-single.md
@@ -93,4 +93,4 @@ This endpoint responds with a single Transaction.  See [transaction resource](./
 ## Possible Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no account whose ID matches the `address` argument.
+- [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no transaction whose ID matches the `hash` argument.

--- a/src/github.com/stellar/horizon/resource/account.go
+++ b/src/github.com/stellar/horizon/resource/account.go
@@ -9,10 +9,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Populate fills out the resource's fields
 func (this *Account) Populate(ctx context.Context, row db.AccountRecord) (err error) {
 	this.ID = row.Accountid
 	this.PT = row.PagingToken()
-	this.Address = row.Accountid
+	this.AccountID = row.Accountid
 	this.Sequence = row.Seqnum
 	this.SubentryCount = row.Numsubentries
 	this.InflationDestination = row.Inflationdest.String

--- a/src/github.com/stellar/horizon/resource/history_account.go
+++ b/src/github.com/stellar/horizon/resource/history_account.go
@@ -8,7 +8,7 @@ import (
 func (this *HistoryAccount) Populate(ctx context.Context, row db.HistoryAccountRecord) {
 	this.ID = row.Address
 	this.PT = row.PagingToken()
-	this.Address = row.Address
+	this.AccountID = row.Address
 }
 
 func (this HistoryAccount) PagingToken() string {

--- a/src/github.com/stellar/horizon/resource/main.go
+++ b/src/github.com/stellar/horizon/resource/main.go
@@ -48,6 +48,7 @@ type AccountThresholds struct {
 	HighThreshold byte `json:"high_threshold"`
 }
 
+// Asset represents a single asset
 type Asset base.Asset
 
 // Balance represents an account's holdings for a single currency type
@@ -57,14 +58,15 @@ type Balance struct {
 	base.Asset
 }
 
-// HistoryAccount is a simple resource, used for the account collection
-// actions.  It provides only the TotalOrderID of the account and its address.
+// HistoryAccount is a simple resource, used for the account collection actions.
+// It provides only the TotalOrderID of the account and its account id.
 type HistoryAccount struct {
-	ID      string `json:"id"`
-	PT      string `json:"paging_token"`
-	Address string `json:"address"`
+	ID        string `json:"id"`
+	PT        string `json:"paging_token"`
+	AccountID string `json:"account_id"`
 }
 
+// Ledger represents a single closed ledger
 type Ledger struct {
 	Links struct {
 		Self         hal.Link `json:"self"`
@@ -105,6 +107,7 @@ type Offer struct {
 	Price   string `json:"price"`
 }
 
+// OrderBookSummary represents a snapshot summary of a given order book
 type OrderBookSummary struct {
 	Bids    []PriceLevel `json:"bids"`
 	Asks    []PriceLevel `json:"asks"`
@@ -125,8 +128,10 @@ type Path struct {
 	Path                   []Asset `json:"path"`
 }
 
+// Price represents a price
 type Price base.Price
 
+// PriceLevel represents an aggregation of offers that share a given price
 type PriceLevel struct {
 	PriceR Price  `json:"price_r"`
 	Price  string `json:"price"`
@@ -154,8 +159,8 @@ type Root struct {
 
 // Signer represents one of an account's signers.
 type Signer struct {
-	Address string `json:"address"`
-	Weight  int32  `json:"weight"`
+	PublicKey string `json:"public_key"`
+	Weight    int32  `json:"weight"`
 }
 
 // Trade represents a trade effect
@@ -208,11 +213,15 @@ type Transaction struct {
 	ValidBefore     string    `json:"valid_before,omitempty"`
 }
 
+// TransactionResultCodes represent a summary of result codes returned from
+// a single xdr TransactionResult
 type TransactionResultCodes struct {
 	TransactionCode string   `json:"transaction"`
 	OperationCodes  []string `json:"operations,omitempty"`
 }
 
+// TransactionSuccess represents the result of a successful transaction
+// submission.
 type TransactionSuccess struct {
 	Links struct {
 		Transaction hal.Link `json:"transaction"`

--- a/src/github.com/stellar/horizon/resource/root.go
+++ b/src/github.com/stellar/horizon/resource/root.go
@@ -15,8 +15,8 @@ func (res *Root) Populate(ctx context.Context, row db.LedgerState, hVersion stri
 	res.StellarCoreVersion = cVersion
 
 	lb := hal.LinkBuilder{httpx.BaseURL(ctx)}
-	res.Links.Account = lb.Link("/accounts/{address}")
-	res.Links.AccountTransactions = lb.PagedLink("/accounts/{address}/transactions")
+	res.Links.Account = lb.Link("/accounts/{account_id}")
+	res.Links.AccountTransactions = lb.PagedLink("/accounts/{account_id}/transactions")
 	res.Links.Friendbot = lb.Link("/friendbot{?addr}")
 	res.Links.Metrics = lb.Link("/metrics")
 	res.Links.OrderBook = lb.Link("/order_book{?selling_asset_type,selling_asset_code,selling_issuer,buying_asset_type,buying_asset_code,buying_issuer}")

--- a/src/github.com/stellar/horizon/resource/signer.go
+++ b/src/github.com/stellar/horizon/resource/signer.go
@@ -5,12 +5,16 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Populate fills out the fields of the signer, using one of an account's
+// secondary signers.
 func (this *Signer) Populate(ctx context.Context, row db.CoreSignerRecord) {
-	this.Address = row.Publickey
+	this.PublicKey = row.Publickey
 	this.Weight = row.Weight
 }
 
+// PopulateMaster fills out the fields of the signer, using a stellar account to
+// provide the data.
 func (this *Signer) PopulateMaster(row db.AccountRecord) {
-	this.Address = row.Accountid
+	this.PublicKey = row.Accountid
 	this.Weight = int32(row.Thresholds[0])
 }


### PR DESCRIPTION
This PR updates the documentation for horizon, as well as changing the external resources to use either `account_id` or `public_key` as appropriate.
