### PR TITLE
Improve Orderbook/Trading examples; Docs whitespace consistency

### DIFF
--- a/docs/reference/accounts-single.md
+++ b/docs/reference/accounts-single.md
@@ -49,34 +49,68 @@ This endpoint responds with the details of a single account for a given ID. See 
 ```json
 {
   "_links": {
-    "effects": {
-      "href": "/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/effects/{?cursor,limit,order}",
-      "templated": true
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB"
     },
-    "offers": {
-      "href": "/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/offers/{?cursor,limit,order}",
+    "transactions": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/transactions{?cursor,limit,order}",
       "templated": true
     },
     "operations": {
-      "href": "/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/operations/{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/operations{?cursor,limit,order}",
       "templated": true
     },
-    "self": {
-      "href": "/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36"
+    "payments": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/payments{?cursor,limit,order}",
+      "templated": true
     },
-    "transactions": {
-      "href": "/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/transactions/{?cursor,limit,order}",
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "offers": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/Offers{?cursor,limit,order}",
       "templated": true
     }
   },
-  "id": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
-  "paging_token": "66035122180096",
-  "account_id": "GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36",
-  "sequence": 66035122176002,
+  "id": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
+  "paging_token": "7275146318450689",
+  "account_id": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
+  "sequence": 7275146318446606,
+  "subentry_count": 5,
+  "thresholds": {
+    "low_threshold": 0,
+    "med_threshold": 0,
+    "high_threshold": 0
+  },
+  "flags": {
+    "auth_required": false,
+    "auth_revocable": false
+  },
   "balances": [
     {
-      "asset_type": "native",
-      "balance": 999999980
+      "balance": "126.8107491",
+      "limit": "5000.0000000",
+      "asset_type": "credit_alphanum4",
+      "asset_code": "BAR",
+      "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+    },
+    {
+      "balance": "294.0000000",
+      "limit": "922337203685.4775807",
+      "asset_type": "credit_alphanum4",
+      "asset_code": "FOO",
+      "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+    },
+    {
+      "balance": "9997.6802725",
+      "asset_type": "native"
+    }
+  ],
+  "signers": [
+    {
+      "public_key": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
+      "weight": 1
     }
   ]
 }

--- a/docs/reference/offers-for-account.md
+++ b/docs/reference/offers-for-account.md
@@ -23,7 +23,7 @@ GET /accounts/{account}/offers{?cursor,limit,order}
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKSXL6D34ERAJYQSPYA6X6AI7HYW36/offers"
+curl "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers"
 ```
 
 ### JavaScript Example Request
@@ -32,7 +32,7 @@ curl "https://horizon-testnet.stellar.org/accounts/GA2HGBJIJKI6O4XEM7CZWY5PS6GKS
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server({hostname:'horizon-testnet.stellar.org', secure:true, port:443});
 
-server.offers("accounts", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ")
+server.offers('accounts', 'GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4')
   .call()
   .then(function (offerResult) {
     console.log(offerResult);
@@ -45,6 +45,86 @@ server.offers("accounts", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS67
 ## Response
 
 The list of offers.
+
+### Example Response
+
+```js
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=asc&limit=10&cursor="
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=asc&limit=10&cursor=122"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4/offers?order=desc&limit=10&cursor=121"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/offers/121"
+          },
+          "offer_maker": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+          }
+        },
+        "id": 121,
+        "paging_token": "121",
+        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "BAR",
+          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+        },
+        "buying": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "FOO",
+          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+        },
+        "amount": "23.6692509",
+        "price_r": {
+          "n": 387,
+          "d": 50
+        },
+        "price": "7.7400000"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/offers/122"
+          },
+          "offer_maker": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+          }
+        },
+        "id": 122,
+        "paging_token": "122",
+        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
+        "selling": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "BAR",
+          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+        },
+        "buying": {
+          "asset_type": "credit_alphanum4",
+          "asset_code": "FOO",
+          "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+        },
+        "amount": "72.0000000",
+        "price_r": {
+          "n": 779,
+          "d": 100
+        },
+        "price": "7.7900000"
+      }
+    ]
+  }
+}
+```
 
 ## Possible Errors
 

--- a/docs/reference/orderbook-details.md
+++ b/docs/reference/orderbook-details.md
@@ -29,15 +29,16 @@ GET /order_book?selling_asset_type={selling_asset_type}&selling_asset_code={sell
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
+curl "https://horizon-testnet.stellar.org/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=FOO&buying_asset_issuer=GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
 ```
+
 ### JavaScript Example Request
 
 ```js
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server({hostname:'horizon-testnet.stellar.org', secure:true, port:443});
 
-server.orderbook(new StellarSdk.Asset("EUR", "GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQOH2LHEDX3EKVIQRLMESGBG"), new StellarSdk.Asset("USD", "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"))
+server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
   .call()
   .then(function(resp) { console.log(resp); })
   .catch(function(err) { console.log(err); })
@@ -46,6 +47,40 @@ server.orderbook(new StellarSdk.Asset("EUR", "GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQ
 ## Response
 
 The summary of the orderbook and its bids and asks.
+
+## Example Response
+```json
+{
+  "bids": [
+    {
+      "price_r": {
+        "n": 100000000,
+        "d": 12953367
+      },
+      "price": "7.7200005",
+      "amount": "12.0000000"
+    }
+  ],
+  "asks": [
+    {
+      "price_r": {
+        "n": 194,
+        "d": 25
+      },
+      "price": "7.7600000",
+      "amount": "238.4804125"
+    }
+  ],
+  "base": {
+    "asset_type": "native"
+  },
+  "counter": {
+    "asset_type": "credit_alphanum4",
+    "asset_code": "FOO",
+    "asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+  }
+}
+```
 
 ## Possible Errors
 

--- a/docs/reference/path-finding.md
+++ b/docs/reference/path-finding.md
@@ -28,7 +28,7 @@ GET /paths?destination_account={da}&source_account={sa}&destination_asset_type={
 | `?destination_asset_code`   | string | The code for the destination, if destination_asset_type is not "native"                            | `GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V` |
 | `?destination_asset_issuer` | string | The issuer for the destination, if destination_asset_type is not "native"                          | `GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V` |
 | `?destination_amount`       | string | The amount, denominated in the destination asset, that any returned path should be able to satisfy | `10.1`                                                     |
-| `?source_account`           | string | The sender's account id.  Any returned path must use a source that the sender can hold                | `GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP` |
+| `?source_account`           | string | The sender's account id.  Any returned path must use a source that the sender can hold             | `GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP` |
 
 
 
@@ -46,64 +46,65 @@ This endpoint responds with a page of path resources.  See [path resource](./res
 
 ```json
 {
-    "_embedded": {
-        "records": [
-            {
-                "destination_amount": "20.0000000",
-                "destination_asset_code": "EUR",
-                "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                "destination_asset_type": "credit_alphanum4",
-                "path": [],
-                "source_amount": "30.0000000",
-                "source_asset_code": "USD",
-                "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                "source_asset_type": "credit_alphanum4"
-            },
-            {
-                "destination_amount": "20.0000000",
-                "destination_asset_code": "EUR",
-                "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                "destination_asset_type": "credit_alphanum4",
-                "path": [
-                    {
-                        "asset_code": "1",
-                        "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                        "asset_type": "credit_alphanum4"
-                    }
-                ],
-                "source_amount": "20.0000000",
-                "source_asset_code": "USD",
-                "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                "source_asset_type": "credit_alphanum4"
-            },
-            {
-                "destination_amount": "20.0000000",
-                "destination_asset_code": "EUR",
-                "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                "destination_asset_type": "credit_alphanum4",
-                "path": [
-                    {
-                        "asset_code": "21",
-                        "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                        "asset_type": "credit_alphanum4"
-                    },
-                    {
-                        "asset_code": "22",
-                        "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                        "asset_type": "credit_alphanum4"
-                    }
-                ],
-                "source_amount": "20.0000000",
-                "source_asset_code": "USD",
-                "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
-                "source_asset_type": "credit_alphanum4"
-            }        ]
-    },
-    "_links": {
-        "self": {
-            "href": "/paths"
-        }
+  "_embedded": {
+    "records": [
+      {
+        "destination_amount": "20.0000000",
+        "destination_asset_code": "EUR",
+        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "destination_asset_type": "credit_alphanum4",
+        "path": [],
+        "source_amount": "30.0000000",
+        "source_asset_code": "USD",
+        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "source_asset_type": "credit_alphanum4"
+      },
+      {
+        "destination_amount": "20.0000000",
+        "destination_asset_code": "EUR",
+        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "destination_asset_type": "credit_alphanum4",
+        "path": [
+          {
+            "asset_code": "1",
+            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+            "asset_type": "credit_alphanum4"
+          }
+        ],
+        "source_amount": "20.0000000",
+        "source_asset_code": "USD",
+        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "source_asset_type": "credit_alphanum4"
+      },
+      {
+        "destination_amount": "20.0000000",
+        "destination_asset_code": "EUR",
+        "destination_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "destination_asset_type": "credit_alphanum4",
+        "path": [
+          {
+            "asset_code": "21",
+            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+            "asset_type": "credit_alphanum4"
+          },
+          {
+            "asset_code": "22",
+            "asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+            "asset_type": "credit_alphanum4"
+          }
+        ],
+        "source_amount": "20.0000000",
+        "source_asset_code": "USD",
+        "source_asset_issuer": "GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN",
+        "source_asset_type": "credit_alphanum4"
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "/paths"
     }
+  }
 }
 ```
 

--- a/docs/reference/trades-for-orderbook.md
+++ b/docs/reference/trades-for-orderbook.md
@@ -29,7 +29,7 @@ GET /order_book/trades?selling_asset_type={selling_asset_type}&selling_asset_cod
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/order_book/trades?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=USD&buying_asset_issuer=GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"
+curl "https://horizon-testnet.stellar.org/order_book/trades?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=FOO&buying_asset_issuer=GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
 ```
 
 ### JavaScript Example Request
@@ -38,7 +38,7 @@ curl "https://horizon-testnet.stellar.org/order_book/trades?selling_asset_type=n
 var StellarSdk = require('stellar-sdk');
 var server = new StellarSdk.Server({hostname:'horizon-testnet.stellar.org', secure:true, port:443});
 
-server.orderbook(new StellarSdk.Asset("EUR", "GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQOH2LHEDX3EKVIQRLMESGBG"), new StellarSdk.Asset("USD", "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4"))
+server.orderbook(new StellarSdk.Asset.native(), new StellarSdk.Asset('FOO', 'GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG'))
   .trades()
   .call()
   .then(function(resp) { console.log(resp); })
@@ -48,6 +48,69 @@ server.orderbook(new StellarSdk.Asset("EUR", "GCQPYGH4K57XBDENKKX55KDTWOTK5WDWRQ
 ## Response
 
 The list of trades.
+
+### Example Response
+```js
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/order_book/trades?order=asc\u0026limit=10\u0026cursor="
+    },
+    "next": {
+      "href": "https://horizon-testnet.stellar.org/order_book/trades?order=asc\u0026limit=10\u0026cursor=7281919481876481-2"
+    },
+    "prev": {
+      "href": "https://horizon-testnet.stellar.org/order_book/trades?order=desc\u0026limit=10\u0026cursor=7281893712072705-2"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+          },
+          "seller": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+          },
+          "buyer": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB"
+          }
+        },
+        "id": "7281893712072705-2",
+        "paging_token": "7281893712072705-2",
+        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
+        "sold_asset_type": "native",
+        "buyer": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
+        "bought_asset_type": "credit_alphanum4",
+        "bought_asset_code": "FOO",
+        "bought_asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+          },
+          "seller": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4"
+          },
+          "buyer": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB"
+          }
+        },
+        "id": "7281919481876481-2",
+        "paging_token": "7281919481876481-2",
+        "seller": "GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4",
+        "sold_asset_type": "native",
+        "buyer": "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
+        "bought_asset_type": "credit_alphanum4",
+        "bought_asset_code": "FOO",
+        "bought_asset_issuer": "GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG"
+      }
+    ]
+  }
+}
+```
 
 ## Possible Errors
 

--- a/docs/reference/transactions-create.md
+++ b/docs/reference/transactions-create.md
@@ -32,8 +32,8 @@ POST /transactions
 
 ### Arguments
 
-| name | loc  |  notes   |                                                                                                                                                                                                                 example                                                                                                                                                                                                                  | description |
-| ---- | ---- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| name | loc  |  notes   |         example        | description |
+| ---- | ---- | -------- | ---------------------- | ----------- |
 | `tx` | body | required | `AAAAAO`....`f4yDBA==` | Base64 representation of transaction envelope [XDR](../learn/xdr.md) |
 
 
@@ -67,11 +67,11 @@ If the transaction failed or errored, then an error response will be returned. P
 
 ```json
 {
-    "hash": "c492d87c4642815dfb3c7dcce01af4effd162b031064098a0d786b6e0a00fd74",
-    "ledger": 2,
-    "envelope_xdr": "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA",
-		"result_xdr": "xJLYfEZCgV37PH3M4Br07/0WKwMQZAmKDXhrbgoA/XQAAAAAAAAACgAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==",
-		"result_meta_xdr": "AAAAAAAAAAEAAAABAAAAAgAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcBY0V4XYn/9gAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msoAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wFjRXgh7zX2AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+  "hash": "c492d87c4642815dfb3c7dcce01af4effd162b031064098a0d786b6e0a00fd74",
+  "ledger": 2,
+  "envelope_xdr": "AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAACgAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAKZ7IPj/46PuWU6ZOtyMosctNAkXRNX9WCAI5RnfRk+AyxDLoDZP/9l3NvsxQtWj9juQOuoBlFLnWu8intgxQA",
+  "result_xdr": "xJLYfEZCgV37PH3M4Br07/0WKwMQZAmKDXhrbgoA/XQAAAAAAAAACgAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==",
+  "result_meta_xdr": "AAAAAAAAAAEAAAABAAAAAgAAAAAAAAAAYvwdC9CRsrYcDdZWNGsqaNfTR8bywsjubQRHAlb8BfcBY0V4XYn/9gAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msoAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wFjRXgh7zX2AAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
 }
 ```
 
@@ -80,4 +80,3 @@ If the transaction failed or errored, then an error response will be returned. P
 - The [standard errors](../learn/errors.md#Standard_Errors).
 - [transaction_failed](./errors/transaction-failed.md): The transaction failed and could not be applied to the ledger.
 - [transaction_malformed](./errors/transaction-malformed.md): The transaction could not be decoded and was not submitted to the network.
-


### PR DESCRIPTION
In order to generate better examples for the three Orderbook and Trading endpoints, I created 3 accounts:

```
Issuer: GBAUUA74H4XOQYRSOW2RZUA4QL5PB37U3JS5NE3RTB2ELJVMIF5RLMAG
Offerer 1: GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB
Offerer 2: GCJ34JYMXNI7N55YREWAACMMZECOMTPIYDTFCQBWPUP7BLJQDDTVGUW4
```

I also updated the Single Account endpoint here since now Horizon gives more information.
