### PR TITLE
Fix build_artifacts.bash

### DIFF
--- a/scripts/build_artifacts.bash
+++ b/scripts/build_artifacts.bash
@@ -30,11 +30,7 @@ build() {
 
 srcBin() {
 	GOOS=$1
-	BIN="horizon"
-
-	if [ "$GOOS" != "$CURRENT_GOOS" ]; then
-		BIN+="-$GOOS-$GOARCH"
-	fi
+	BIN="federation-$GOOS-$GOARCH"
 
 	if [ "$GOOS" = "windows" ]; then
 		BIN+=".exe"

--- a/scripts/build_artifacts.bash
+++ b/scripts/build_artifacts.bash
@@ -30,7 +30,7 @@ build() {
 
 srcBin() {
 	GOOS=$1
-	BIN="federation-$GOOS-$GOARCH"
+	BIN="horizon-$GOOS-$GOARCH"
 
 	if [ "$GOOS" = "windows" ]; then
 		BIN+=".exe"


### PR DESCRIPTION
gb maintainers merged constabulary/gb#533 and now all cross-compiled
binaries' names have the same format.
