### PR TITLE
DOCS: add frontmatter item `laboratoryUrl` for each endpoint

### DIFF
--- a/docs/reference/accounts-all.md
+++ b/docs/reference/accounts-all.md
@@ -1,5 +1,7 @@
 ---
 title: All Accounts
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=accounts&endpoint=all
 ---
 
 The all accounts endpoint returns a collection of all the [accounts](./resources/account.md) that have ever existed. Results

--- a/docs/reference/accounts-single.md
+++ b/docs/reference/accounts-single.md
@@ -1,5 +1,7 @@
 ---
 title: Account Details
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=accounts&endpoint=single
 ---
 
 Returns information and links relating to a single [account](./resources/account.md).

--- a/docs/reference/effects-all.md
+++ b/docs/reference/effects-all.md
@@ -1,5 +1,7 @@
 ---
 title: All Effects
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=all
 ---
 
 This endpoint represents all [effects](./resources/effect.md).
@@ -112,4 +114,3 @@ The list of effects.
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
 - [not_found](./errors/not-found.md): A `not_found` error will be returned if there are no effects for the given account.
-

--- a/docs/reference/effects-for-account.md
+++ b/docs/reference/effects-for-account.md
@@ -1,5 +1,7 @@
 ---
 title: Effects for Account
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_account
 ---
 
 This endpoint represents all [effects](./resources/effect.md) that changed a given [account](./resources/account.md). It will return relevant effects from the creation of the account to the current ledger.

--- a/docs/reference/effects-for-ledger.md
+++ b/docs/reference/effects-for-ledger.md
@@ -1,5 +1,7 @@
 ---
 title: Effects for Ledger
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_ledger
 ---
 
 Effects are the specific ways that the ledger was changed by any operation.

--- a/docs/reference/effects-for-operation.md
+++ b/docs/reference/effects-for-operation.md
@@ -1,5 +1,7 @@
 ---
 title: Effects for Operation
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_operation
 ---
 
 This endpoint represents all [effects](./resources/effect.md) that occurred as a result of a given [operation](./resources/operation.md).
@@ -130,4 +132,3 @@ This endpoint responds with a list of effects on the ledger as a result of a giv
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
 - [not_found](./errors/not-found.md): A `not_found` errors will be returned if there are no effects for operation whose ID matches the `id` argument.
-

--- a/docs/reference/effects-for-transaction.md
+++ b/docs/reference/effects-for-transaction.md
@@ -1,5 +1,7 @@
 ---
 title: Effects for Transaction
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=effects&endpoint=for_transaction
 ---
 
 This endpoint represents all [effects](./resources/effect.md) that occurred as a result of a given [transaction](./resources/transaction.md).

--- a/docs/reference/ledgers-all.md
+++ b/docs/reference/ledgers-all.md
@@ -1,5 +1,7 @@
 ---
 title: All Ledgers
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=ledgers&endpoint=all
 ---
 
 This endpoint represents all [ledgers](./resources/ledger.md).
@@ -159,6 +161,3 @@ This endpoint responds with a list of ledgers.  See [ledger resource](./resource
 ## Errors
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
-
-
-

--- a/docs/reference/ledgers-single.md
+++ b/docs/reference/ledgers-single.md
@@ -1,5 +1,7 @@
 ---
 title: Ledger Details
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=ledgers&endpoint=single
 ---
 
 The ledger details endpoint provides information on a single [ledger](./resources/ledger.md).
@@ -79,6 +81,3 @@ This endpoint responds with a single Ledger.  See [ledger resource](./resources/
 
 - The [standard errors](../learn/errors.md#Standard_Errors).
 - [not_found](./errors/not-found.md): A `not_found` error will be returned if there is no ledger whose ID matches the `id` argument.
-
-
-

--- a/docs/reference/offers-for-account.md
+++ b/docs/reference/offers-for-account.md
@@ -1,5 +1,7 @@
 ---
 title: Offers for Account
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=offers&endpoint=for_account
 ---
 
 People on the Stellar network can make [offers](./resources/offer.md) to buy or sell assets.  This endpoint represents all the offers a particular account makes.

--- a/docs/reference/operations-all.md
+++ b/docs/reference/operations-all.md
@@ -1,5 +1,7 @@
 ---
 title: All Operations
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=all
 ---
 
 This endpoint represents all [operations](./resources/operation.md) that are part of validated [transactions](./resources/transaction.md).

--- a/docs/reference/operations-for-account.md
+++ b/docs/reference/operations-for-account.md
@@ -1,5 +1,7 @@
 ---
 title: Operations for Account
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=for_account
 ---
 
 This endpoint represents all [operations](./resources/operation.md) that were included in valid [transactions](./resources/transaction.md) that affected a particular [account](./resources/account.md).

--- a/docs/reference/operations-for-ledger.md
+++ b/docs/reference/operations-for-ledger.md
@@ -1,5 +1,7 @@
 ---
 title: Operations for Ledger
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=for_ledger
 ---
 
 This endpoint returns all [operations](./resources/operation.md) that occurred in a given [ledger](./resources/ledger.md).

--- a/docs/reference/operations-for-transaction.md
+++ b/docs/reference/operations-for-transaction.md
@@ -1,5 +1,7 @@
 ---
 title: Operations for Transaction
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=for_transaction
 ---
 
 This endpoint represents all [operations](./resources/operation.md) that are part of a given [transaction](./resources/transaction.md).

--- a/docs/reference/operations-single.md
+++ b/docs/reference/operations-single.md
@@ -1,5 +1,7 @@
 ---
 title: Operation Details
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=operations&endpoint=single
 ---
 
 The operation details endpoint provides information on a single [operation](./resources/operation.md). The operation ID provided in the `id` argument specifies which operation to load.

--- a/docs/reference/orderbook-details.md
+++ b/docs/reference/orderbook-details.md
@@ -1,5 +1,7 @@
 ---
 title: Orderbook Details
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=order_book&endpoint=details
 ---
 
 People on the Stellar network can make [offers](./resources/offer.md) to buy or sell assets.  These offers are summarized by the assets being bought and sold in [orderbooks](./resources/orderbook.md).

--- a/docs/reference/path-finding.md
+++ b/docs/reference/path-finding.md
@@ -1,6 +1,7 @@
 ---
 title: Find Payment Paths
-category: Endpoints
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=paths&endpoint=all
 ---
 
 The Stellar Network allows payments to be made across assets through _path payments_.  A path payment specifies a series of assets to route a payment through, from source asset (the asset debited from the payer) to destination asset (the asset credited to the payee).

--- a/docs/reference/payments-all.md
+++ b/docs/reference/payments-all.md
@@ -1,5 +1,7 @@
 ---
 title: All Payments
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=all
 ---
 
 This endpoint represents all payment [operations](./resources/operation.md) that are part of validated [transactions](./resources/transaction.md). This endpoint can also be used in [streaming](../learn/responses.md#streaming) mode so it is possible to use it to listen for new payments as they get made in the Stellar network.

--- a/docs/reference/payments-for-account.md
+++ b/docs/reference/payments-for-account.md
@@ -1,5 +1,7 @@
 ---
 title: Payments for Account
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_account
 ---
 
 This endpoint responds with a collection of [Payment operations](./resources/operation.md) where the given [account](./resources/account.md) was either the sender or receiver.

--- a/docs/reference/payments-for-ledger.md
+++ b/docs/reference/payments-for-ledger.md
@@ -1,5 +1,7 @@
 ---
 title: Payments for Ledger
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_ledger
 ---
 
 This endpoint represents all payment [operations](./resources/operation.md) that are part of a valid [transactions](./resources/transaction.md) in a given [ledger](./resources/ledger.md).

--- a/docs/reference/payments-for-transaction.md
+++ b/docs/reference/payments-for-transaction.md
@@ -1,5 +1,7 @@
 ---
 title: Payments for Transaction
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=payments&endpoint=for_transaction
 ---
 
 This endpoint represents all payment [operations](./resources/operation.md) that are part of a given [transaction](./resources/transaction.md).

--- a/docs/reference/trades-for-orderbook.md
+++ b/docs/reference/trades-for-orderbook.md
@@ -1,5 +1,7 @@
 ---
 title: Trades for Orderbook
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=order_book&endpoint=trades
 ---
 
 People on the Stellar network can make [offers](./resources/offer.md) to buy or sell assets.  These offers are summarized by the assets being bought and sold in [orderbooks](./resources/orderbook.md).  When an offer is fully or partially fulfilled, a [trade](./resources/trade.md) happens.

--- a/docs/reference/transactions-all.md
+++ b/docs/reference/transactions-all.md
@@ -1,5 +1,7 @@
 ---
 title: All Transactions
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=all
 ---
 
 This endpoint represents all validated [transactions](./resources/transaction.md).

--- a/docs/reference/transactions-create.md
+++ b/docs/reference/transactions-create.md
@@ -1,5 +1,7 @@
 ---
 title: Post Transaction
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=create
 ---
 
 Posts a new [transaction](./resources/transaction.md) to the Stellar Network.

--- a/docs/reference/transactions-for-account.md
+++ b/docs/reference/transactions-for-account.md
@@ -1,5 +1,7 @@
 ---
 title: Transactions for Account
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=for_account
 ---
 
 This endpoint represents all [transactions](./resources/transaction.md) that affected a given [account](./resources/account.md).

--- a/docs/reference/transactions-for-ledger.md
+++ b/docs/reference/transactions-for-ledger.md
@@ -1,5 +1,7 @@
 ---
 title: Transactions for Ledger
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=for_ledger
 ---
 
 This endpoint represents all [transactions](./resources/transaction.md) in a given [ledger](./resources/ledger.md).

--- a/docs/reference/transactions-single.md
+++ b/docs/reference/transactions-single.md
@@ -1,5 +1,7 @@
 ---
 title: Transaction Details
+clientData:
+  laboratoryUrl: https://www.stellar.org/laboratory/#explorer?resource=transactions&endpoint=single
 ---
 
 The transaction details endpoint provides information on a single [transaction](./resources/transaction.md). The transaction hash provided in the `hash` argument specifies which transaction to load.


### PR DESCRIPTION
This adds data that is passed to js scripts on the developer site pages. This is used to link from the endpoint reference docs to the relevant page in the laboratory.

This data is used in the laboratory in a feature implemented in this PR: https://github.com/stellar/developers/pull/44
