### PR TITLE
fix accounts-all example typo

### DIFF
--- a/docs/reference/accounts-all.md
+++ b/docs/reference/accounts-all.md
@@ -27,7 +27,7 @@ GET /accounts{?cursor,limit,order}
 ### curl Example Request
 
 ```shell
-curl "https://horizon-testnet.stellar.org/transactions?limit=200&order=desc"
+curl "https://horizon-testnet.stellar.org/accounts?limit=200&order=desc"
 ```
 
 ### JavaScript Example Request


### PR DESCRIPTION
I've checked all the other curl reference examples and they are correct. Only this one was broken.
