### PR TITLE
Change outlier Offers link to lowercase for consistency

### DIFF
--- a/docs/reference/accounts-single.md
+++ b/docs/reference/accounts-single.md
@@ -71,7 +71,7 @@ This endpoint responds with the details of a single account for a given ID. See 
       "templated": true
     },
     "offers": {
-      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/Offers{?cursor,limit,order}",
+      "href": "https://horizon-testnet.stellar.org/accounts/GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB/offers{?cursor,limit,order}",
       "templated": true
     }
   },

--- a/src/github.com/stellar/horizon/resource/account.go
+++ b/src/github.com/stellar/horizon/resource/account.go
@@ -52,7 +52,7 @@ func (this *Account) Populate(ctx context.Context, row db.AccountRecord) (err er
 	this.Links.Operations = lb.PagedLink(self, "operations")
 	this.Links.Payments = lb.PagedLink(self, "payments")
 	this.Links.Effects = lb.PagedLink(self, "effects")
-	this.Links.Offers = lb.PagedLink(self, "Offers")
+	this.Links.Offers = lb.PagedLink(self, "offers")
 
 	return
 }


### PR DESCRIPTION
I recently got a result with the link:

``` json
    "offers": {
      "href": "https://horizon-testnet.stellar.org/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/Offers{?cursor,limit,order}",
      "templated": true
    }
```

It tripped up my template parse because I expected last path item to be lowercase `offers` just as https://github.com/stellar/horizon/blob/master/src/github.com/stellar/horizon/init_web.go has it as lowercase.
