### PR TITLE
Clear result slices when using `Select`

### DIFF
--- a/src/github.com/stellar/horizon/db2/repo_test.go
+++ b/src/github.com/stellar/horizon/db2/repo_test.go
@@ -61,4 +61,11 @@ func TestRepo(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(0, count)
 
+	// ensure that selecting into a populated slice clears the slice first
+	scenarios.Load(tdb.StellarCoreURL(), "base-core.sql")
+	require.Len(ids, 4, "ids slice was not preloaded with data")
+	err = repo.SelectRaw(&ids, "SELECT txid FROM txhistory limit 2")
+	assert.NoError(err)
+	assert.Len(ids, 2)
+
 }


### PR DESCRIPTION
This PR restores the load semantics from the first db package such that destination slices are cleared before being loaded with the new records.  

Be restoring these semantics, this PR also fixes a duplicate result bug when streaming results.
