### PR TITLE
Add recovery to ingestion

### DIFF
--- a/src/github.com/stellar/horizon/errors/main.go
+++ b/src/github.com/stellar/horizon/errors/main.go
@@ -1,8 +1,40 @@
 package errors
 
 import (
+	"fmt"
+	"net/http"
+
+	"github.com/getsentry/raven-go"
 	"github.com/go-errors/errors"
 )
+
+// FromPanic extracts the err from the result of a recover() call.
+func FromPanic(rec interface{}) error {
+	err, ok := rec.(error)
+	if !ok {
+		err = fmt.Errorf("%s", rec)
+	}
+
+	return errors.Wrap(err, 4)
+}
+
+// ReportToSentry reports err to the configured sentry server.  Optionally,
+// specifying a non-nil `r` will include information in the report about the
+// current http request.
+func ReportToSentry(err error, r *http.Request) {
+	st := raven.NewStacktrace(4, 3, []string{"github.org/stellar"})
+	exc := raven.NewException(err, st)
+
+	var packet *raven.Packet
+	if r != nil {
+		h := raven.NewHttp(r)
+		packet = raven.NewPacket(err.Error(), exc, h)
+	} else {
+		packet = raven.NewPacket(err.Error(), exc)
+	}
+
+	raven.Capture(packet, nil)
+}
 
 // Stack returns the stack, as a string, if one can be extracted from `err`.
 func Stack(err error) string {

--- a/src/github.com/stellar/horizon/ingest/ingester.go
+++ b/src/github.com/stellar/horizon/ingest/ingester.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"github.com/stellar/horizon/db2/core"
 	"github.com/stellar/horizon/db2/history"
+	"github.com/stellar/horizon/errors"
 	"github.com/stellar/horizon/log"
 )
 
@@ -114,6 +115,15 @@ func (i *System) run() {
 // run causes the importer to check stellar-core to see if we can import new
 // data.
 func (i *System) runOnce() {
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			err := errors.FromPanic(rec)
+			log.Errorf("import session panicked: %s", err)
+			errors.ReportToSentry(err, nil)
+		}
+	}()
+
 	// 1. find the latest ledger
 	// 2. if any available, import until none available
 	// 3. if any were imported, go to 1

--- a/src/github.com/stellar/horizon/ingest/session.go
+++ b/src/github.com/stellar/horizon/ingest/session.go
@@ -3,7 +3,6 @@ package ingest
 import (
 	"encoding/base64"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/stellar/go-stellar-base/amount"

--- a/src/github.com/stellar/horizon/ingest/session.go
+++ b/src/github.com/stellar/horizon/ingest/session.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/stellar/go-stellar-base/amount"
@@ -20,6 +21,8 @@ func (is *Session) Run() {
 	if is.Err != nil {
 		return
 	}
+
+	defer is.Ingestion.Rollback()
 
 	for is.Cursor.NextLedger() {
 		if is.Err != nil {


### PR DESCRIPTION
This PR makes it such that a panic in the course of ingestion will not crash the entire horizon server.  In addition, it fixes a potential database connection leak by ensuring that transactions are finished even when a panic occurs.

Closes #265
