### PR TITLE
Remove broken paging_token on account resource

### DIFF
--- a/docs/reference/resources/account.md
+++ b/docs/reference/resources/account.md
@@ -12,7 +12,6 @@ When horizon returns information about an account it uses the following format:
 | Attribute    | Type             |                                                                                                                        |
 |--------------|------------------|------------------------------------------------------------------------------------------------------------------------|
 | id           | string           | The canonical id of this account, suitable for use as the :id parameter for url templates that require an account's ID. |
-| paging_token | number           | A [paging token](./page.md) suitable for use as a `cursor` parameter.                                                                |
 | account_id      | string           | The account's public key encoded into a base32 string representation.                                                    |
 | sequence     | number           | The current sequence number that can be used when submitting a transaction from this account.                           |
 | balances     | array of objects | An array of the native asset or credits this account holds.                                                          |
@@ -52,7 +51,6 @@ When horizon returns information about an account it uses the following format:
     }
   },
   "id": "GAOEWNUEKXKNGB2AAOX6S6FEP6QKCFTU7KJH647XTXQXTMOAUATX2VF5",
-  "paging_token": "132564165595136",
   "account_id": "GAOEWNUEKXKNGB2AAOX6S6FEP6QKCFTU7KJH647XTXQXTMOAUATX2VF5",
   "sequence": 132564165591040,
   "balances": [
@@ -68,7 +66,6 @@ When horizon returns information about an account it uses the following format:
 
 | Resource                 | Type       | Resource URI Template                |
 |--------------------------|------------|--------------------------------------|
-| [All Accounts](../accounts-all.md)         | Collection | `/accounts`                          |
 | [Account Details](../accounts-single.md)      | Single     | `/accounts/:id`                      |
 | [Account Transactions](../transactions-for-account.md) | Collection | `/accounts/:account_id/transactions` |
 | [Account Operations](../operations-for-account.md)   | Collection | `/accounts/:account_id/operations`   |

--- a/src/github.com/stellar/horizon/db2/history/main.go
+++ b/src/github.com/stellar/horizon/db2/history/main.go
@@ -100,7 +100,7 @@ const (
 
 // Account is a row of data from the `history_accounts` table
 type Account struct {
-	TotalOrderID
+	ID      int64
 	Address string `db:"address"`
 }
 

--- a/src/github.com/stellar/horizon/resource/account.go
+++ b/src/github.com/stellar/horizon/resource/account.go
@@ -20,7 +20,6 @@ func (this *Account) Populate(
 	ha history.Account,
 ) (err error) {
 	this.ID = ca.Accountid
-	this.PT = ha.PagingToken()
 	this.AccountID = ca.Accountid
 	this.Sequence = ca.Seqnum
 	this.SubentryCount = ca.Numsubentries

--- a/src/github.com/stellar/horizon/resource/history_account.go
+++ b/src/github.com/stellar/horizon/resource/history_account.go
@@ -7,10 +7,5 @@ import (
 
 func (this *HistoryAccount) Populate(ctx context.Context, row history.Account) {
 	this.ID = row.Address
-	this.PT = row.PagingToken()
 	this.AccountID = row.Address
-}
-
-func (this HistoryAccount) PagingToken() string {
-	return this.PT
 }


### PR DESCRIPTION
With the release of 0.6.0, the notion of a paging token for accounts became non-sensical since we lost the ability to know about all accounts.  Unfortunately, I forgot to remove it from the JSON responses for account state, and so it continued to be populated.

This PR corrects that mistake.
