### PR TITLE
error on import manifest importpath for gogi/gogi

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -521,7 +521,7 @@
 			"path": "/web"
 		},
 		{
-			"importpath": "goji.io",
+			"importpath": "github.com/goji/gogi",
 			"repository": "https://github.com/goji/goji",
 			"revision": "0d89ff54b2c18c9c4ba530e32496aef902d3c6cd",
 			"branch": "master"


### PR DESCRIPTION
importpath had a typo causing error on gb vendor restore
FATAL: command "restore" failed: Could not process dependency: "goji.io" is not a valid import path
FATAL: command "vendor" failed: exit status 1.. (edited)