### PR TITLE
Adds `created_at` to trade resource

### DIFF
--- a/src/github.com/stellar/horizon/actions_trade.go
+++ b/src/github.com/stellar/horizon/actions_trade.go
@@ -108,6 +108,7 @@ func (action *TradeIndexAction) loadPage() {
 		if !found {
 			msg := fmt.Sprintf("could not find ledger data for sequence %d", record.LedgerSequence())
 			action.Err = errors.New(msg)
+			return
 		}
 
 		action.Err = res.Populate(action.Ctx, record, ledger)

--- a/src/github.com/stellar/horizon/actions_trade_test.go
+++ b/src/github.com/stellar/horizon/actions_trade_test.go
@@ -3,6 +3,10 @@ package horizon
 import (
 	"net/url"
 	"testing"
+	"time"
+
+	"github.com/stellar/horizon/db2/history"
+	"github.com/stellar/horizon/resource"
 )
 
 func TestTradeActions_Index(t *testing.T) {
@@ -14,6 +18,16 @@ func TestTradeActions_Index(t *testing.T) {
 	if ht.Assert.Equal(200, w.Code) {
 		ht.Assert.PageOf(1, w.Body)
 	}
+
+	// 	ensure created_at is populated correctly
+	records := []resource.Trade{}
+	ht.UnmarshalPage(w.Body, &records)
+
+	l := history.Ledger{}
+	hq := history.Q{Repo: ht.HorizonRepo()}
+	ht.Require.NoError(hq.LedgerBySequence(&l, 6))
+
+	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)
 
 	// for order book
 	var q = make(url.Values)

--- a/src/github.com/stellar/horizon/db2/history/effect.go
+++ b/src/github.com/stellar/horizon/db2/history/effect.go
@@ -31,6 +31,12 @@ func (r *Effect) ID() string {
 	return fmt.Sprintf("%019d-%010d", r.HistoryOperationID, r.Order)
 }
 
+// LedgerSequence return the ledger in which the effect occurred.
+func (r *Effect) LedgerSequence() int32 {
+	id := toid.Parse(r.HistoryOperationID)
+	return id.LedgerSequence
+}
+
 // PagingToken returns a cursor for this effect
 func (r *Effect) PagingToken() string {
 	return fmt.Sprintf("%d-%d", r.HistoryOperationID, r.Order)

--- a/src/github.com/stellar/horizon/db2/history/ledger.go
+++ b/src/github.com/stellar/horizon/db2/history/ledger.go
@@ -1,7 +1,10 @@
 package history
 
 import (
+	"fmt"
+
 	sq "github.com/lann/squirrel"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/horizon/db2"
 )
 
@@ -21,6 +24,18 @@ func (q *Q) Ledgers() *LedgersQ {
 		parent: q,
 		sql:    selectLedger,
 	}
+}
+
+// LedgersBySequence loads the a set of ledgers identified by the sequences
+// `seqs` into `dest`.
+func (q *Q) LedgersBySequence(dest interface{}, seqs ...interface{}) error {
+	if len(seqs) == 0 {
+		return errors.New("no sequence arguments provided")
+	}
+	in := fmt.Sprintf("sequence IN (%s)", sq.Placeholders(len(seqs)))
+	sql := selectLedger.Where(in, seqs...)
+
+	return q.Select(dest, sql)
 }
 
 // Page specifies the paging constraints for the query being built by `q`.

--- a/src/github.com/stellar/horizon/db2/history/ledger_test.go
+++ b/src/github.com/stellar/horizon/db2/history/ledger_test.go
@@ -27,4 +27,11 @@ func TestLedgerQueries(t *testing.T) {
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(ls, 3)
 	}
+
+	// LedgersBySequence
+	err = q.LedgersBySequence(&ls, 1, 2, 3)
+
+	if tt.Assert.NoError(err) {
+		tt.Assert.Len(ls, 3)
+	}
 }

--- a/src/github.com/stellar/horizon/db2/history/ledger_test.go
+++ b/src/github.com/stellar/horizon/db2/history/ledger_test.go
@@ -33,5 +33,14 @@ func TestLedgerQueries(t *testing.T) {
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Len(ls, 3)
+
+		foundSeqs := make([]int32, len(ls))
+		for i := range ls {
+			foundSeqs[i] = ls[i].Sequence
+		}
+
+		tt.Assert.Contains(foundSeqs, int32(1))
+		tt.Assert.Contains(foundSeqs, int32(2))
+		tt.Assert.Contains(foundSeqs, int32(3))
 	}
 }

--- a/src/github.com/stellar/horizon/resource/main.go
+++ b/src/github.com/stellar/horizon/resource/main.go
@@ -193,18 +193,19 @@ type Trade struct {
 		Buyer  hal.Link `json:"buyer"`
 	} `json:"_links"`
 
-	ID                string `json:"id"`
-	PT                string `json:"paging_token"`
-	Seller            string `json:"seller"`
-	SoldAmount        string `json:"sold_amount"`
-	SoldAssetType     string `json:"sold_asset_type"`
-	SoldAssetCode     string `json:"sold_asset_code,omitempty"`
-	SoldAssetIssuer   string `json:"sold_asset_issuer,omitempty"`
-	Buyer             string `json:"buyer"`
-	BoughtAmount      string `json:"bought_amount"`
-	BoughtAssetType   string `json:"bought_asset_type"`
-	BoughtAssetCode   string `json:"bought_asset_code,omitempty"`
-	BoughtAssetIssuer string `json:"bought_asset_issuer,omitempty"`
+	ID                string    `json:"id"`
+	PT                string    `json:"paging_token"`
+	Seller            string    `json:"seller"`
+	SoldAmount        string    `json:"sold_amount"`
+	SoldAssetType     string    `json:"sold_asset_type"`
+	SoldAssetCode     string    `json:"sold_asset_code,omitempty"`
+	SoldAssetIssuer   string    `json:"sold_asset_issuer,omitempty"`
+	Buyer             string    `json:"buyer"`
+	BoughtAmount      string    `json:"bought_amount"`
+	BoughtAssetType   string    `json:"bought_asset_type"`
+	BoughtAssetCode   string    `json:"bought_asset_code,omitempty"`
+	BoughtAssetIssuer string    `json:"bought_asset_issuer,omitempty"`
+	LedgerCloseTime   time.Time `json:"created_at"`
 }
 
 // Transaction represents a single, successful transaction

--- a/src/github.com/stellar/horizon/resource/trade.go
+++ b/src/github.com/stellar/horizon/resource/trade.go
@@ -19,6 +19,12 @@ func (res *Trade) Populate(
 		err = errors.New("invalid effect; not a trade")
 		return
 	}
+
+	if row.LedgerSequence() != ledger.Sequence {
+		err = errors.New("invalid ledger; different sequence than trade")
+		return
+	}
+
 	row.UnmarshalDetails(res)
 	res.ID = row.PagingToken()
 	res.PT = row.PagingToken()

--- a/src/github.com/stellar/horizon/resource/trade.go
+++ b/src/github.com/stellar/horizon/resource/trade.go
@@ -10,7 +10,11 @@ import (
 )
 
 // Populate fills out the details
-func (res *Trade) Populate(ctx context.Context, row history.Effect) (err error) {
+func (res *Trade) Populate(
+	ctx context.Context,
+	row history.Effect,
+	ledger history.Ledger,
+) (err error) {
 	if row.Type != history.EffectTrade {
 		err = errors.New("invalid effect; not a trade")
 		return
@@ -19,6 +23,7 @@ func (res *Trade) Populate(ctx context.Context, row history.Effect) (err error) 
 	res.ID = row.PagingToken()
 	res.PT = row.PagingToken()
 	res.Buyer = row.Account
+	res.LedgerCloseTime = ledger.ClosedAt
 
 	lb := hal.LinkBuilder{httpx.BaseURL(ctx)}
 	res.Links.Self = lb.Link("/accounts", res.Seller)


### PR DESCRIPTION
- db2/history: adds LedgersBySequence to load batch of ledgers based upon the loaded page of trades
- resource: Trade#Populate takes a history.Ledger to populate additional data