### PR TITLE
Update horizon for latest monorepo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-- '1.6'
+- '1.7'
+- '1.8'
 - tip
 install:
   - go get github.com/constabulary/gb/...

--- a/src/github.com/stellar/horizon/action.go
+++ b/src/github.com/stellar/horizon/action.go
@@ -35,7 +35,7 @@ type Action struct {
 // CoreQ provides access to queries that access the stellar core database.
 func (action *Action) CoreQ() *core.Q {
 	if action.cq == nil {
-		action.cq = &core.Q{Repo: action.App.CoreRepo(action.Ctx)}
+		action.cq = &core.Q{Session: action.App.CoreSession(action.Ctx)}
 	}
 
 	return action.cq
@@ -82,7 +82,7 @@ func (action *Action) GetPageQuery() db2.PageQuery {
 // horizon's database.
 func (action *Action) HistoryQ() *history.Q {
 	if action.hq == nil {
-		action.hq = &history.Q{Repo: action.App.HorizonRepo(action.Ctx)}
+		action.hq = &history.Q{Session: action.App.HorizonSession(action.Ctx)}
 	}
 
 	return action.hq

--- a/src/github.com/stellar/horizon/actions_trade_test.go
+++ b/src/github.com/stellar/horizon/actions_trade_test.go
@@ -24,7 +24,7 @@ func TestTradeActions_Index(t *testing.T) {
 	ht.UnmarshalPage(w.Body, &records)
 
 	l := history.Ledger{}
-	hq := history.Q{Repo: ht.HorizonRepo()}
+	hq := history.Q{Session: ht.HorizonSession()}
 	ht.Require.NoError(hq.LedgerBySequence(&l, 6))
 
 	ht.Assert.WithinDuration(l.ClosedAt, records[0].LedgerCloseTime, 1*time.Second)

--- a/src/github.com/stellar/horizon/app.go
+++ b/src/github.com/stellar/horizon/app.go
@@ -127,8 +127,8 @@ func (a *App) Close() {
 	a.cancel()
 	a.ticks.Stop()
 
-	a.historyQ.Repo.DB.Close()
-	a.coreQ.Repo.DB.Close()
+	a.historyQ.Session.DB.Close()
+	a.coreQ.Session.DB.Close()
 }
 
 // HistoryQ returns a helper object for performing sql queries against the
@@ -137,16 +137,16 @@ func (a *App) HistoryQ() *history.Q {
 	return a.historyQ
 }
 
-// HorizonRepo returns a new repo that loads data from the horizon database. The
-// returned repo is bound to `ctx`.
-func (a *App) HorizonRepo(ctx context.Context) *db.Repo {
-	return &db.Repo{DB: a.historyQ.Repo.DB, Ctx: ctx}
+// HorizonSession returns a new session that loads data from the horizon
+// database. The returned session is bound to `ctx`.
+func (a *App) HorizonSession(ctx context.Context) *db.Session {
+	return &db.Session{DB: a.historyQ.Session.DB, Ctx: ctx}
 }
 
-// CoreRepo returns a new repo that loads data from the stellar core
-// database. The returned repo is bound to `ctx`.
-func (a *App) CoreRepo(ctx context.Context) *db.Repo {
-	return &db.Repo{DB: a.coreQ.Repo.DB, Ctx: ctx}
+// CoreSession returns a new session that loads data from the stellar core
+// database. The returned session is bound to `ctx`.
+func (a *App) CoreSession(ctx context.Context) *db.Session {
+	return &db.Session{DB: a.coreQ.Session.DB, Ctx: ctx}
 }
 
 // CoreQ returns a helper object for performing sql queries aginst the
@@ -257,8 +257,8 @@ func (a *App) UpdateMetrics() {
 	a.coreLatestLedgerGauge.Update(int64(ls.CoreLatest))
 	a.coreElderLedgerGauge.Update(int64(ls.CoreElder))
 
-	a.horizonConnGauge.Update(int64(a.historyQ.Repo.DB.Stats().OpenConnections))
-	a.coreConnGauge.Update(int64(a.coreQ.Repo.DB.Stats().OpenConnections))
+	a.horizonConnGauge.Update(int64(a.historyQ.Session.DB.Stats().OpenConnections))
+	a.coreConnGauge.Update(int64(a.coreQ.Session.DB.Stats().OpenConnections))
 }
 
 // DeleteUnretainedHistory forwards to the app's reaper.  See

--- a/src/github.com/stellar/horizon/db2/core/account.go
+++ b/src/github.com/stellar/horizon/db2/core/account.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/xdr"
 )
 

--- a/src/github.com/stellar/horizon/db2/core/account_data.go
+++ b/src/github.com/stellar/horizon/db2/core/account_data.go
@@ -2,7 +2,8 @@ package core
 
 import (
 	"encoding/base64"
-	sq "github.com/lann/squirrel"
+
+	sq "github.com/Masterminds/squirrel"
 )
 
 // Raw returns the decoded, raw value of the account data

--- a/src/github.com/stellar/horizon/db2/core/ledger_header.go
+++ b/src/github.com/stellar/horizon/db2/core/ledger_header.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 )
 
 // LedgerHeaderBySequence is a query that loads a single row from the

--- a/src/github.com/stellar/horizon/db2/core/main.go
+++ b/src/github.com/stellar/horizon/db2/core/main.go
@@ -73,7 +73,7 @@ type OrderBookSummary []OrderBookSummaryPriceLevel
 // Q is a helper struct on which to hang common queries against a stellar
 // core database.
 type Q struct {
-	*db.Repo
+	*db.Session
 }
 
 // PriceLevel represents an aggregation of offers to trade at a certain

--- a/src/github.com/stellar/horizon/db2/core/main_test.go
+++ b/src/github.com/stellar/horizon/db2/core/main_test.go
@@ -9,7 +9,7 @@ import (
 func TestLatestLedger(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	var seq int
 	err := q.LatestLedger(&seq)
@@ -22,7 +22,7 @@ func TestLatestLedger(t *testing.T) {
 func TestElderLedger(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	var elder int32
 	err := q.ElderLedger(&elder)

--- a/src/github.com/stellar/horizon/db2/core/offer.go
+++ b/src/github.com/stellar/horizon/db2/core/offer.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/go-errors/errors"
-	sq "github.com/lann/squirrel"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/horizon/db2"
 )

--- a/src/github.com/stellar/horizon/db2/core/offer_test.go
+++ b/src/github.com/stellar/horizon/db2/core/offer_test.go
@@ -10,7 +10,7 @@ import (
 func TestOffersByAddress(t *testing.T) {
 	tt := test.Start(t).Scenario("trades")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	var offers []Offer
 

--- a/src/github.com/stellar/horizon/db2/core/order_book_summary_test.go
+++ b/src/github.com/stellar/horizon/db2/core/order_book_summary_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetOrderBookSummary(t *testing.T) {
 	tt := test.Start(t).Scenario("order_books")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	selling, err := AssetFromDB(xdr.AssetTypeAssetTypeCreditAlphanum4, "USD", "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4")
 	tt.Require.NoError(err)
@@ -68,7 +68,7 @@ func TestGetOrderBookSummary(t *testing.T) {
 func TestGetOrderBookSummary_Regress310(t *testing.T) {
 	tt := test.Start(t).Scenario("order_books_310")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	selling, err := AssetFromDB(xdr.AssetTypeAssetTypeCreditAlphanum4, "USD", "GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4")
 	tt.Require.NoError(err)

--- a/src/github.com/stellar/horizon/db2/core/signer.go
+++ b/src/github.com/stellar/horizon/db2/core/signer.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 )
 
 // SignersByAddress loads all signer rows for `addy`

--- a/src/github.com/stellar/horizon/db2/core/transaction.go
+++ b/src/github.com/stellar/horizon/db2/core/transaction.go
@@ -4,8 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
-	sq "github.com/lann/squirrel"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/horizon/utf8"

--- a/src/github.com/stellar/horizon/db2/core/transaction_fee.go
+++ b/src/github.com/stellar/horizon/db2/core/transaction_fee.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/xdr"
 )
 

--- a/src/github.com/stellar/horizon/db2/core/transaction_fee_test.go
+++ b/src/github.com/stellar/horizon/db2/core/transaction_fee_test.go
@@ -9,7 +9,7 @@ import (
 func TestTransactionFeesByLedger(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	var fees []TransactionFee
 	err := q.TransactionFeesByLedger(&fees, 2)

--- a/src/github.com/stellar/horizon/db2/core/transaction_test.go
+++ b/src/github.com/stellar/horizon/db2/core/transaction_test.go
@@ -9,7 +9,7 @@ import (
 func TestTransactionsQueries(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.CoreRepo()}
+	q := &Q{tt.CoreSession()}
 
 	// Test TransactionsByLedger
 	var txs []Transaction

--- a/src/github.com/stellar/horizon/db2/core/trustline.go
+++ b/src/github.com/stellar/horizon/db2/core/trustline.go
@@ -2,7 +2,8 @@ package core
 
 import (
 	"errors"
-	sq "github.com/lann/squirrel"
+
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/xdr"
 )
 

--- a/src/github.com/stellar/horizon/db2/history/account.go
+++ b/src/github.com/stellar/horizon/db2/history/account.go
@@ -1,7 +1,7 @@
 package history
 
 import (
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/horizon/db2"
 )
 

--- a/src/github.com/stellar/horizon/db2/history/account_test.go
+++ b/src/github.com/stellar/horizon/db2/history/account_test.go
@@ -9,7 +9,7 @@ import (
 func TestAccountQueries(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.HorizonRepo()}
+	q := &Q{tt.HorizonSession()}
 
 	// Test Accounts()
 	acs := []Account{}

--- a/src/github.com/stellar/horizon/db2/history/effect.go
+++ b/src/github.com/stellar/horizon/db2/history/effect.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/horizon/db2"

--- a/src/github.com/stellar/horizon/db2/history/ledger.go
+++ b/src/github.com/stellar/horizon/db2/history/ledger.go
@@ -3,7 +3,7 @@ package history
 import (
 	"fmt"
 
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/horizon/db2"
 )

--- a/src/github.com/stellar/horizon/db2/history/ledger_test.go
+++ b/src/github.com/stellar/horizon/db2/history/ledger_test.go
@@ -10,7 +10,7 @@ import (
 func TestLedgerQueries(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.HorizonRepo()}
+	q := &Q{tt.HorizonSession()}
 
 	// Test LedgerBySequence
 	var l Ledger

--- a/src/github.com/stellar/horizon/db2/history/main.go
+++ b/src/github.com/stellar/horizon/db2/history/main.go
@@ -5,8 +5,8 @@ package history
 import (
 	"time"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
-	sq "github.com/lann/squirrel"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
@@ -184,7 +184,7 @@ type OperationsQ struct {
 // Q is a helper struct on which to hang common queries against a history
 // portion of the horizon database.
 type Q struct {
-	*db.Repo
+	*db.Session
 }
 
 // TotalOrderID represents the ID portion of rows that are identified by the

--- a/src/github.com/stellar/horizon/db2/history/main_test.go
+++ b/src/github.com/stellar/horizon/db2/history/main_test.go
@@ -1,14 +1,15 @@
 package history
 
 import (
-	"github.com/stellar/horizon/test"
 	"testing"
+
+	"github.com/stellar/horizon/test"
 )
 
 func TestLatestLedger(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.HorizonRepo()}
+	q := &Q{tt.HorizonSession()}
 
 	var seq int
 	err := q.LatestLedger(&seq)
@@ -21,7 +22,7 @@ func TestLatestLedger(t *testing.T) {
 func TestElderLedger(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.HorizonRepo()}
+	q := &Q{tt.HorizonSession()}
 
 	var seq int
 	err := q.ElderLedger(&seq)

--- a/src/github.com/stellar/horizon/db2/history/operation.go
+++ b/src/github.com/stellar/horizon/db2/history/operation.go
@@ -3,8 +3,8 @@ package history
 import (
 	"encoding/json"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/go-errors/errors"
-	sq "github.com/lann/squirrel"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/horizon/db2"
 	"github.com/stellar/horizon/toid"

--- a/src/github.com/stellar/horizon/db2/history/operation_test.go
+++ b/src/github.com/stellar/horizon/db2/history/operation_test.go
@@ -9,7 +9,7 @@ import (
 func TestOperationQueries(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.HorizonRepo()}
+	q := &Q{tt.HorizonSession()}
 
 	// Test OperationByID
 	var op Operation

--- a/src/github.com/stellar/horizon/db2/history/transaction.go
+++ b/src/github.com/stellar/horizon/db2/history/transaction.go
@@ -1,7 +1,7 @@
 package history
 
 import (
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/horizon/db2"
 	"github.com/stellar/horizon/toid"
 )

--- a/src/github.com/stellar/horizon/db2/history/transaction_test.go
+++ b/src/github.com/stellar/horizon/db2/history/transaction_test.go
@@ -10,7 +10,7 @@ import (
 func TestTransactionQueries(t *testing.T) {
 	tt := test.Start(t).Scenario("base")
 	defer tt.Finish()
-	q := &Q{tt.HorizonRepo()}
+	q := &Q{tt.HorizonSession()}
 
 	// Test TransactionByHash
 	var tx Transaction

--- a/src/github.com/stellar/horizon/db2/page_query.go
+++ b/src/github.com/stellar/horizon/db2/page_query.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/go-errors/errors"
-	sq "github.com/lann/squirrel"
 )
 
 const (

--- a/src/github.com/stellar/horizon/db2/schema/main.go
+++ b/src/github.com/stellar/horizon/db2/schema/main.go
@@ -30,7 +30,7 @@ var Migrations migrate.MigrationSource = &migrate.AssetMigrationSource{
 }
 
 // Init installs the latest schema into db after clearing it first
-func Init(db *db.Repo) error {
+func Init(db *db.Session) error {
 	return db.ExecAll(string(MustAsset("latest.sql")))
 }
 

--- a/src/github.com/stellar/horizon/db2/sqx/main.go
+++ b/src/github.com/stellar/horizon/db2/sqx/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 )
 
 // StringArray returns a sq.Expr suitable for inclusion in an insert that represents

--- a/src/github.com/stellar/horizon/db2/sqx/main_test.go
+++ b/src/github.com/stellar/horizon/db2/sqx/main_test.go
@@ -3,7 +3,7 @@ package sqx
 import (
 	"testing"
 
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/horizon/test"
 )
 

--- a/src/github.com/stellar/horizon/ingest/cursor_test.go
+++ b/src/github.com/stellar/horizon/ingest/cursor_test.go
@@ -14,7 +14,7 @@ func TestCursor(t *testing.T) {
 	c := Cursor{
 		FirstLedger: 7,
 		LastLedger:  10,
-		DB:          tt.CoreRepo(),
+		DB:          tt.CoreSession(),
 	}
 
 	// Ledger 7

--- a/src/github.com/stellar/horizon/ingest/ingestion.go
+++ b/src/github.com/stellar/horizon/ingest/ingestion.go
@@ -7,8 +7,8 @@ import (
 
 	"math"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
-	sq "github.com/lann/squirrel"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/horizon/db2/core"
 	"github.com/stellar/horizon/db2/history"
@@ -329,7 +329,7 @@ func (ingest *Ingestion) getParticipantID(
 	aid xdr.AccountId,
 ) (result int64, err error) {
 
-	q := history.Q{Repo: ingest.DB}
+	q := history.Q{Session: ingest.DB}
 	var existing history.Account
 	err = q.AccountByAddress(&existing, aid.Address())
 

--- a/src/github.com/stellar/horizon/ingest/ledger_bundle.go
+++ b/src/github.com/stellar/horizon/ingest/ledger_bundle.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Load runs queries against `core` to fill in the records of the bundle.
-func (lb *LedgerBundle) Load(db *db.Repo) error {
-	q := &core.Q{Repo: db}
+func (lb *LedgerBundle) Load(db *db.Session) error {
+	q := &core.Q{Session: db}
 	// Load Header
 	err := q.LedgerHeaderBySequence(&lb.Header, lb.Sequence)
 	if err != nil {

--- a/src/github.com/stellar/horizon/ingest/ledger_bundle_test.go
+++ b/src/github.com/stellar/horizon/ingest/ledger_bundle_test.go
@@ -11,7 +11,7 @@ func TestLedgerBundleLoad(t *testing.T) {
 	defer tt.Finish()
 
 	bundle := &LedgerBundle{Sequence: 2}
-	err := bundle.Load(tt.CoreRepo())
+	err := bundle.Load(tt.CoreSession())
 
 	if tt.Assert.NoError(err) {
 		tt.Assert.Equal(uint32(2), bundle.Header.Sequence)

--- a/src/github.com/stellar/horizon/ingest/main.go
+++ b/src/github.com/stellar/horizon/ingest/main.go
@@ -6,7 +6,7 @@ package ingest
 import (
 	"sync"
 
-	sq "github.com/lann/squirrel"
+	sq "github.com/Masterminds/squirrel"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/horizon/db2/core"
@@ -33,7 +33,7 @@ type Cursor struct {
 	// attempt to be ingested in this session.
 	LastLedger int32
 	// DB is the stellar-core db that data is ingested from.
-	DB *db.Repo
+	DB *db.Session
 
 	Metrics *IngesterMetrics
 
@@ -70,10 +70,10 @@ type LedgerBundle struct {
 type System struct {
 	// HorizonDB is the connection to the horizon database that ingested data will
 	// be written to.
-	HorizonDB *db.Repo
+	HorizonDB *db.Session
 
 	// CoreDB is the stellar-core db that data is ingested from.
-	CoreDB *db.Repo
+	CoreDB *db.Session
 
 	Metrics IngesterMetrics
 
@@ -102,9 +102,9 @@ type IngesterMetrics struct {
 
 // Ingestion receives write requests from a Session
 type Ingestion struct {
-	// DB is the sql repo to be used for writing any rows into the horizon
+	// DB is the sql connection to be used for writing any rows into the horizon
 	// database.
-	DB *db.Repo
+	DB *db.Session
 
 	ledgers                  sq.InsertBuilder
 	transactions             sq.InsertBuilder
@@ -153,7 +153,7 @@ type Session struct {
 
 // New initializes the ingester, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(network string, coreURL string, core, horizon *db.Repo) *System {
+func New(network string, coreURL string, core, horizon *db.Session) *System {
 	i := &System{
 		Network:        network,
 		StellarCoreURL: coreURL,

--- a/src/github.com/stellar/horizon/ingest/main_test.go
+++ b/src/github.com/stellar/horizon/ingest/main_test.go
@@ -52,7 +52,7 @@ func sys(tt *test.T) *System {
 	return New(
 		network.TestNetworkPassphrase,
 		"",
-		tt.CoreRepo(),
-		tt.HorizonRepo(),
+		tt.CoreSession(),
+		tt.HorizonSession(),
 	)
 }

--- a/src/github.com/stellar/horizon/ingest/participants/main_test.go
+++ b/src/github.com/stellar/horizon/ingest/participants/main_test.go
@@ -11,7 +11,7 @@ import (
 func TestForOperation(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
-	q := &core.Q{Repo: tt.CoreRepo()}
+	q := &core.Q{Session: tt.CoreSession()}
 
 	load := func(lg int32, tx int, op int) []xdr.AccountId {
 		var txs []core.Transaction
@@ -89,7 +89,7 @@ func TestForOperation(t *testing.T) {
 func TestForTransaction(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
-	q := &core.Q{Repo: tt.CoreRepo()}
+	q := &core.Q{Session: tt.CoreSession()}
 
 	load := func(lg int32, tx int, op int) []xdr.AccountId {
 		var txs []core.Transaction

--- a/src/github.com/stellar/horizon/ingest/system.go
+++ b/src/github.com/stellar/horizon/ingest/system.go
@@ -48,7 +48,7 @@ func (i *System) ReingestAll() (int, error) {
 
 	var coreElder int32
 	var coreLatest int32
-	cq := core.Q{Repo: i.CoreDB}
+	cq := core.Q{Session: i.CoreDB}
 
 	err = cq.ElderLedger(&coreElder)
 	if err != nil {
@@ -71,7 +71,7 @@ func (i *System) ReingestAll() (int, error) {
 // ReingestOutdated finds old ledgers and reimports them.
 func (i *System) ReingestOutdated() (n int, err error) {
 
-	q := history.Q{Repo: i.HorizonDB}
+	q := history.Q{Session: i.HorizonDB}
 
 	err = i.trimAbandondedLedgers()
 	if err != nil {
@@ -266,7 +266,7 @@ func (i *System) runOnce() {
 // mode.
 func (i *System) trimAbandondedLedgers() error {
 	var coreElder int32
-	cq := core.Q{Repo: i.CoreDB}
+	cq := core.Q{Session: i.CoreDB}
 
 	err := cq.ElderLedger(&coreElder)
 	if err != nil {

--- a/src/github.com/stellar/horizon/ingest/system_test.go
+++ b/src/github.com/stellar/horizon/ingest/system_test.go
@@ -18,7 +18,7 @@ func TestClearAll(t *testing.T) {
 
 	// ensure no ledgers
 	var found int
-	err = tt.HorizonRepo().GetRaw(&found, "SELECT COUNT(*) FROM history_ledgers")
+	err = tt.HorizonSession().GetRaw(&found, "SELECT COUNT(*) FROM history_ledgers")
 	tt.Require.NoError(err)
 	tt.Assert.Equal(0, found)
 }
@@ -27,13 +27,13 @@ func TestValidation(t *testing.T) {
 	tt := test.Start(t).ScenarioWithoutHorizon("kahuna")
 	defer tt.Finish()
 
-	sys := New(network.TestNetworkPassphrase, "", tt.CoreRepo(), tt.HorizonRepo())
+	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession())
 
 	// intact chain
 	for i := int32(2); i <= 57; i++ {
 		tt.Assert.NoError(sys.validateLedgerChain(i))
 	}
-	_, err := tt.CoreRepo().ExecRaw(
+	_, err := tt.CoreSession().ExecRaw(
 		`DELETE FROM ledgerheaders WHERE ledgerseq = ?`, 5,
 	)
 	tt.Require.NoError(err)
@@ -49,7 +49,7 @@ func TestValidation(t *testing.T) {
 	tt.Assert.Contains(err.Error(), "failed to load prev ledger")
 
 	// mismatched header
-	_, err = tt.CoreRepo().ExecRaw(`
+	_, err = tt.CoreSession().ExecRaw(`
 		UPDATE ledgerheaders
 		SET ledgerhash = ?
 		WHERE ledgerseq = ?`, "00000", 8)

--- a/src/github.com/stellar/horizon/init_db.go
+++ b/src/github.com/stellar/horizon/init_db.go
@@ -8,27 +8,27 @@ import (
 )
 
 func initHorizonDb(app *App) {
-	repo, err := db.Open("postgres", app.config.DatabaseURL)
+	session, err := db.Open("postgres", app.config.DatabaseURL)
 
 	if err != nil {
 		log.Panic(err)
 	}
-	repo.DB.SetMaxIdleConns(4)
-	repo.DB.SetMaxOpenConns(12)
+	session.DB.SetMaxIdleConns(4)
+	session.DB.SetMaxOpenConns(12)
 
-	app.historyQ = &history.Q{repo}
+	app.historyQ = &history.Q{session}
 }
 
 func initCoreDb(app *App) {
-	repo, err := db.Open("postgres", app.config.StellarCoreDatabaseURL)
+	session, err := db.Open("postgres", app.config.StellarCoreDatabaseURL)
 
 	if err != nil {
 		log.Panic(err)
 	}
 
-	repo.DB.SetMaxIdleConns(4)
-	repo.DB.SetMaxOpenConns(12)
-	app.coreQ = &core.Q{repo}
+	session.DB.SetMaxIdleConns(4)
+	session.DB.SetMaxOpenConns(12)
+	app.coreQ = &core.Q{session}
 }
 
 func init() {

--- a/src/github.com/stellar/horizon/init_ingester.go
+++ b/src/github.com/stellar/horizon/init_ingester.go
@@ -18,8 +18,8 @@ func initIngester(app *App) {
 	app.ingester = ingest.New(
 		app.networkPassphrase,
 		app.config.StellarCoreURL,
-		app.CoreRepo(nil),
-		app.HorizonRepo(nil),
+		app.CoreSession(nil),
+		app.HorizonSession(nil),
 	)
 
 	app.ingester.SkipCursorUpdate = app.config.SkipCursorUpdate

--- a/src/github.com/stellar/horizon/init_reaper.go
+++ b/src/github.com/stellar/horizon/init_reaper.go
@@ -5,7 +5,7 @@ import (
 )
 
 func initReaper(app *App) {
-	app.reaper = reap.New(app.config.HistoryRetentionCount, app.HorizonRepo(nil))
+	app.reaper = reap.New(app.config.HistoryRetentionCount, app.HorizonSession(nil))
 }
 
 func init() {

--- a/src/github.com/stellar/horizon/init_txsub.go
+++ b/src/github.com/stellar/horizon/init_txsub.go
@@ -1,16 +1,17 @@
 package horizon
 
 import (
+	"net/http"
+
 	"github.com/stellar/horizon/db2/core"
 	"github.com/stellar/horizon/db2/history"
 	"github.com/stellar/horizon/txsub"
-	"github.com/stellar/horizon/txsub/results/db"
+	results "github.com/stellar/horizon/txsub/results/db"
 	"github.com/stellar/horizon/txsub/sequence"
-	"net/http"
 )
 
 func initSubmissionSystem(app *App) {
-	cq := &core.Q{Repo: app.CoreRepo(nil)}
+	cq := &core.Q{Session: app.CoreSession(nil)}
 
 	app.submitter = &txsub.System{
 		Pending:         txsub.NewDefaultSubmissionList(),
@@ -18,7 +19,7 @@ func initSubmissionSystem(app *App) {
 		SubmissionQueue: sequence.NewManager(),
 		Results: &results.DB{
 			Core:    cq,
-			History: &history.Q{Repo: app.HorizonRepo(nil)},
+			History: &history.Q{Session: app.HorizonSession(nil)},
 		},
 		Sequences:         cq.SequenceProvider(),
 		NetworkPassphrase: app.networkPassphrase,

--- a/src/github.com/stellar/horizon/reap/main.go
+++ b/src/github.com/stellar/horizon/reap/main.go
@@ -12,7 +12,7 @@ import (
 
 // System represents the history reaping subsystem of horizon.
 type System struct {
-	HorizonDB      *db.Repo
+	HorizonDB      *db.Session
 	RetentionCount uint
 
 	nextRun time.Time
@@ -20,7 +20,7 @@ type System struct {
 
 // New initializes the reaper, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(retention uint, horizon *db.Repo) *System {
+func New(retention uint, horizon *db.Session) *System {
 	r := &System{
 		HorizonDB:      horizon,
 		RetentionCount: retention,

--- a/src/github.com/stellar/horizon/reap/system_test.go
+++ b/src/github.com/stellar/horizon/reap/system_test.go
@@ -10,7 +10,7 @@ func TestDeleteUnretainedHistory(t *testing.T) {
 	tt := test.Start(t).Scenario("kahuna")
 	defer tt.Finish()
 
-	db := tt.HorizonRepo()
+	db := tt.HorizonSession()
 
 	sys := New(0, db)
 

--- a/src/github.com/stellar/horizon/simplepath/finder_test.go
+++ b/src/github.com/stellar/horizon/simplepath/finder_test.go
@@ -14,7 +14,7 @@ func TestFinder(t *testing.T) {
 	defer tt.Finish()
 
 	finder := &Finder{
-		Q: &core.Q{Repo: tt.CoreRepo()},
+		Q: &core.Q{Session: tt.CoreSession()},
 	}
 
 	native := makeAsset(xdr.AssetTypeAssetTypeNative, "", "")

--- a/src/github.com/stellar/horizon/simplepath/order_book.go
+++ b/src/github.com/stellar/horizon/simplepath/order_book.go
@@ -2,11 +2,12 @@ package simplepath
 
 import (
 	"errors"
-	sq "github.com/lann/squirrel"
+	"math/big"
+
+	sq "github.com/Masterminds/squirrel"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/horizon/assets"
 	"github.com/stellar/horizon/db2/core"
-	"math/big"
 )
 
 // ErrNotEnough represents an error that occurs when pricing a trade on an

--- a/src/github.com/stellar/horizon/simplepath/order_book_test.go
+++ b/src/github.com/stellar/horizon/simplepath/order_book_test.go
@@ -21,7 +21,7 @@ func TestOrderBook(t *testing.T) {
 			xdr.AssetTypeAssetTypeCreditAlphanum4,
 			"USD",
 			"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"),
-		Q: &core.Q{Repo: tt.CoreRepo()},
+		Q: &core.Q{Session: tt.CoreSession()},
 	}
 
 	r, err := ob.Cost(ob.Buying, 10000000)
@@ -65,7 +65,7 @@ func TestOrderBook_BadCost(t *testing.T) {
 			xdr.AssetTypeAssetTypeCreditAlphanum4,
 			"USD",
 			"GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN"),
-		Q: &core.Q{Repo: tt.CoreRepo()},
+		Q: &core.Q{Session: tt.CoreSession()},
 	}
 
 	r, err := ob.Cost(ob.Buying, 10000000)

--- a/src/github.com/stellar/horizon/test/t.go
+++ b/src/github.com/stellar/horizon/test/t.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stellar/horizon/ledger"
 )
 
-// CoreRepo returns a db.Repo instance pointing at the stellar core test database
-func (t *T) CoreRepo() *db.Repo {
-	return &db.Repo{
+// CoreSession returns a db.Session instance pointing at the stellar core test database
+func (t *T) CoreSession() *db.Session {
+	return &db.Session{
 		DB:  t.CoreDB,
 		Ctx: t.Ctx,
 	}
@@ -29,9 +29,10 @@ func (t *T) Finish() {
 	}
 }
 
-// HorizonRepo returns a db.Repo instance pointing at the horizon test database
-func (t *T) HorizonRepo() *db.Repo {
-	return &db.Repo{
+// HorizonSession returns a db.Session instance pointing at the horizon test
+// database
+func (t *T) HorizonSession() *db.Session {
+	return &db.Session{
 		DB:  t.HorizonDB,
 		Ctx: t.Ctx,
 	}
@@ -71,7 +72,7 @@ func (t *T) UnmarshalPage(r io.Reader, dest interface{}) {
 func (t *T) UpdateLedgerState() {
 	var next ledger.State
 
-	err := t.CoreRepo().GetRaw(&next, `
+	err := t.CoreSession().GetRaw(&next, `
 		SELECT
 			COALESCE(MIN(ledgerseq), 0) as core_elder,
 			COALESCE(MAX(ledgerseq), 0) as core_latest
@@ -82,7 +83,7 @@ func (t *T) UpdateLedgerState() {
 		panic(err)
 	}
 
-	err = t.HorizonRepo().GetRaw(&next, `
+	err = t.HorizonSession().GetRaw(&next, `
 			SELECT
 				COALESCE(MIN(sequence), 0) as history_elder,
 				COALESCE(MAX(sequence), 0) as history_latest

--- a/src/github.com/stellar/horizon/txsub/results/db/main_test.go
+++ b/src/github.com/stellar/horizon/txsub/results/db/main_test.go
@@ -13,8 +13,8 @@ func TestResultProvider(t *testing.T) {
 	defer tt.Finish()
 
 	rp := &DB{
-		Core:    &core.Q{Repo: tt.CoreRepo()},
-		History: &history.Q{Repo: tt.HorizonRepo()},
+		Core:    &core.Q{Session: tt.CoreSession()},
+		History: &history.Q{Session: tt.HorizonSession()},
 	}
 
 	// Regression: ensure a transaction that is not ingested still returns the

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -8,6 +8,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/Masterminds/squirrel",
+			"repository": "https://github.com/Masterminds/squirrel",
+			"revision": "20f192218cf52a73397fa2df45bdda720f3e47c8",
+			"branch": "v1"
+		},
+		{
 			"importpath": "github.com/PuerkitoBio/throttled",
 			"repository": "https://github.com/PuerkitoBio/throttled",
 			"revision": "1c8297c643b774435df8df65f7502b37d014fb6b",
@@ -262,12 +268,6 @@
 			"branch": "master"
 		},
 		{
-			"importpath": "github.com/lann/squirrel",
-			"repository": "https://github.com/lann/squirrel",
-			"revision": "e13dbacee404686afd0acf2d44b8d34869605e03",
-			"branch": "master"
-		},
-		{
 			"importpath": "github.com/lib/pq",
 			"repository": "https://github.com/lib/pq",
 			"revision": "a8d8d01c4f91602f876bf5aa210274e8203a6b45",
@@ -318,7 +318,7 @@
 		{
 			"importpath": "github.com/nullstyle/go-xdr/xdr3",
 			"repository": "https://github.com/nullstyle/go-xdr",
-			"revision": "8bf8a5d05c8612d4039a7f67ddce3d49ee61b398",
+			"revision": "3c3a95da20cd1e19018bf098dce9c3ce358848df",
 			"branch": "master",
 			"path": "/xdr3"
 		},
@@ -418,7 +418,7 @@
 		{
 			"importpath": "github.com/stellar/go",
 			"repository": "https://github.com/stellar/go",
-			"revision": "6f020b600298ae09be03545efb717a20c39a6b63",
+			"revision": "79fa0dbbbc5a16ec5c9673929a0cad2ee381e2fe",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This PR also incorporates changes from the db package:  `Repo` has been renamed `Session`