### PR TITLE
Update docs link

### DIFF
--- a/src/github.com/stellar/horizon/actions_transaction.go
+++ b/src/github.com/stellar/horizon/actions_transaction.go
@@ -196,7 +196,7 @@ func (action *TransactionCreateAction) loadResource() {
 			Detail: "The transaction failed when submitted to the stellar network. " +
 				"The `extras.result_codes` field on this response contains further " +
 				"details.  Descriptions of each code can be found at: " +
-				"https://www.stellar.org/developers/learn/concepts/list-of-operations.html",
+				"https://www.stellar.org/developers/guides/concepts/list-of-operations.html",
 			Extras: map[string]interface{}{
 				"envelope_xdr": action.Result.EnvelopeXDR,
 				"result_xdr":   err.ResultXDR,


### PR DESCRIPTION
Horizon was returning a broken link in one of its error handlers, this updates it to the correct link